### PR TITLE
Add steps to reduce surge.sh deploy size

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,6 +35,15 @@ jobs:
       - name: Build for preview
         # Build for preview to build a localized site (only latest guides are built)
         run: vendor/quarkus-l10n-utils/bin/build-for-preview
+
+      # ref. https://github.com/quarkusio/quarkusio.github.io/blob/f935cd0d21acff6e7de9b7c8b6f86622f1104251/.github/workflows/build.yml#L73-L78
+      - name: Reduce the size of the website to be compatible with surge
+        run: |
+          find assets/images/posts/ -mindepth 1 -maxdepth 1 -type d -mtime +100 -exec rm -rf _site/{} \;
+          find newsletter/ -mindepth 1 -maxdepth 1 -type d -mtime +100 -exec rm -rf _site/{} \;
+          rm -rf _site/assets/images/worldtour/2023
+          rm -rf _site/assets/images/desktopwallpapers
+
       - name: Deploy to surge
         # Deploy the site to surge.sh
         # We use surge.sh for pull-request preview because surge.sh supports custom sub-domain and it fits pull-request preview site.


### PR DESCRIPTION
Not to exceed surge.sh deploy size limit, GitHub Actions step is added

Since this change affects only after this pull-request merge, the check for this pull-request itself will fail.
