### PR TITLE
Retranslate _guides/hibernate-panache-next.adoc.po

### DIFF
--- a/l10n/po/ja_JP/_guides/hibernate-orm-panache-kotlin.adoc.po
+++ b/l10n/po/ja_JP/_guides/hibernate-orm-panache-kotlin.adoc.po
@@ -13,7 +13,7 @@ msgstr ""
 #: _guides/hibernate-orm-panache-kotlin.adoc
 #, no-wrap
 msgid "Simplified Hibernate ORM with Panache and Kotlin"
-msgstr "Simplified Hibernate ORM with PanacheとKotlin"
+msgstr "Panache と Kotlin でシンプルになった Hibernate ORM"
 
 #: _guides/hibernate-orm-panache-kotlin.adoc
 msgid ""

--- a/l10n/po/ja_JP/_guides/hibernate-panache-next.adoc.po
+++ b/l10n/po/ja_JP/_guides/hibernate-panache-next.adoc.po
@@ -9,7 +9,7 @@ msgstr ""
 #. mt: gemini
 #: _guides/hibernate-panache-next.adoc
 msgid "Simplified Hibernate with Panache Next"
-msgstr "Panache Next を使用した Hibernate の簡素化"
+msgstr "Panache Next によってシンプルになった Hibernate"
 
 #: _guides/hibernate-panache-next.adoc
 msgid "<a class=\"status-label status-experimental\" title=\"This extension requests early feedback to mature the idea\" href=\"#extension-status-note\">experimental</a>"

--- a/l10n/po/ja_JP/_guides/hibernate-panache-next.adoc.po
+++ b/l10n/po/ja_JP/_guides/hibernate-panache-next.adoc.po
@@ -6,52 +6,52 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: jekyll-l10n\n"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Simplified Hibernate with Panache Next"
-msgstr "簡素化されたHibernateとPanache Next"
+msgstr "Panache Next を使用した Hibernate の簡素化"
 
 #: _guides/hibernate-panache-next.adoc
 msgid "<a class=\"status-label status-experimental\" title=\"This extension requests early feedback to mature the idea\" href=\"#extension-status-note\">experimental</a>"
 msgstr "<a class=\"status-label status-experimental\" title=\"このエクステンションは、アイデアを成熟させるために早期のフィードバックを求めています\" href=\"#extension-status-note\">experimental</a>"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Hibernate with Panache Next is the perfect solution if you want to get started using Hibernate in Quarkus."
-msgstr "Hibernate with Panache Nextは、QuarkusでHibernateを使い始めたい場合に最適なソリューションです。"
+msgstr "Quarkus で Hibernate の使用を開始したい場合、Panache Next を使用した Hibernate は最適なソリューションです。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "This extension is currently experimental, so its API may change, in particular names of\n"
 "classes or packages may change, even the module name. We are in the process of making it a public preview in order\n"
 "to obtain public feedback, so please report feedback either on link:https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/WG.20-.20Panache.2ENext/with/562916276[Zulip]\n"
 "or via link:https://github.com/orgs/quarkusio/projects/50/views/1[GitHub issues]."
-msgstr "この拡張機能は現在実験的なものであり、API は変更されるかもしれません、特にクラス名やパッケージ名、モジュール名さえも変更されるかもしれません。私たちは一般からのフィードバックを得るためにこの拡張機能をパブリックプレビューにしているところです。"
+msgstr "このエクステンションは現在実験段階にあるため、API が変更される可能性があります。特に、クラス名やパッケージ名、さらにはモジュール名も変更される可能性があります。現在、パブリックプレビュー化を進めており、皆様からのフィードバックを求めています。フィードバックは link:https://quarkusio.zulipchat.com/#narrow/channel/187038-dev/topic/WG.20-.20Panache.2ENext/with/562916276[Zulip] または link:https://github.com/orgs/quarkusio/projects/50/views/1[GitHub issues] までお寄せください。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Walk-through"
 msgstr "ウォークスルー"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Let's take a progressive approach to learning how to use Hibernate with Panache, and start with a simple entity."
-msgstr "PanacheでHibernateの使い方を学ぶには、段階的なアプローチを取り、簡単なエンティティから始めましょう。"
+msgstr "Hibernate with Panache の使い方を学ぶために段階的なアプローチをとり、シンプルなエンティティから始めましょう。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "This guide is not going to go into the specifics of using either\n"
 "xref:hibernate-orm.adoc[Hibernate], or its underlying\n"
 "link:{jakarta-persistence-spec-url}[Jakarta Persistence specification],\n"
 "because both already have great documentation that you can and should use for more in-depth knowledge."
-msgstr "このガイドでは、 xref:hibernate-orm.adoc[Hibernateや] その基礎となる link:{jakarta-persistence-spec-url}[Jakarta Persistence仕様の] 具体的な使用方法については説明しません。"
+msgstr "このガイドでは、 xref:hibernate-orm.adoc[Hibernate] またはその基盤となる link:{jakarta-persistence-spec-url}[Jakarta Persistence 仕様] のどちらかの具体的な使用法については詳しく説明しません。なぜなら、どちらもすでに優れたドキュメントがあり、より深い知識を得るために活用できるからです。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Importing the extension, and configuration"
-msgstr "拡張機能のインポートと設定"
+msgstr "エクステンションのインポートと設定"
 
 #: _guides/hibernate-panache-next.adoc
 msgid "pom.xml"
@@ -61,297 +61,297 @@ msgstr "pom.xml\n"
 msgid "build.gradle"
 msgstr "build.gradle"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "You also have to configure the Hibernate processor, which is required:"
-msgstr "また、Hibernateプロセッサの設定も必要です："
+msgstr "また、必須の Hibernate プロセッサーを設定する必要があります。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "You can use any of the xref:hibernate-orm.adoc#setting-up-and-configuring-hibernate-orm[supported JDBC drivers]."
-msgstr "xref:hibernate-orm.adoc#setting-up-and-configuring-hibernate-orm[サポートされているJDBCドライバの] どれでも使用できます。"
+msgstr "xref:hibernate-orm.adoc#setting-up-and-configuring-hibernate-orm[サポートされている JDBC ドライバー] のいずれかを使用できます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "Make sure you configure your datasource in your `application.properties` (although you don't have to in DEV\n"
 "mode: if you don't, a dev service will be provided for you):"
-msgstr "`application.properties` でデータソースを設定してください（DEVモードでは設定する必要はありません：設定しなくてもDEVサービスが提供されます）："
+msgstr "`application.properties` でデータソースを設定してください (ただし、開発モード の場合は必須ではありません。設定しない場合、dev services が提供されます)。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Our first entity"
-msgstr "最初の事業体"
+msgstr "最初のエンティティ"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "What this guide will focus on is the basics of how to use Hibernate with Panache, so let's start with how to\n"
 "create an entity:"
-msgstr "このガイドでは、PanacheでHibernateを使用する方法の基本に焦点を当てます："
+msgstr "このガイドでは、Hibernate with Panache の基本的な使用法に焦点を当てるので、まずエンティティの作成方法から始めましょう。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "In order to map a Java class to a Database table, just:"
-msgstr "Javaクラスをデータベースのテーブルにマッピングするには、次のようにします："
+msgstr "Java クラスをデータベーステーブルにマッピングするには、次の手順を実行します。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Write a class"
-msgstr "クラスを書く"
+msgstr "クラスを作成する"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Annotate it with link:{jakarta-persistence-javadocs-url}/jakarta/persistence/entity[`@Entity`]"
-msgstr "を付けてください。 link:{jakarta-persistence-javadocs-url}/jakarta/persistence/entity[@Entity]"
+msgstr "link:{jakarta-persistence-javadocs-url}/jakarta/persistence/entity[`@Entity`] でアノテーションを付けます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Make it extend `PanacheEntity`"
-msgstr "伸ばす `PanacheEntity`"
+msgstr "`PanacheEntity` を継承させる"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Make its fields `public`"
-msgstr "畑を作る `public`"
+msgstr "フィールドを `public` にする"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "And that's it, now you can start creating instances of your entity, persist it to your database, after which point\n"
 "all changes to its fields will be automatically sent to the database (no need for any explicit `update` instruction),\n"
 "and even remove it from the database:"
-msgstr "これで、エンティティのインスタンスの作成、データベースへの永続化、フィールドへのすべての変更のデータベースへの自動送信（明示的な `update` の指示は不要）、データベースからの削除ができるようになります："
+msgstr "これで完了です。エンティティのインスタンス作成、データベースへの永続化を開始できます。その後は、フィールドへのすべての変更が自動的にデータベースに送信され (明示的な `update` 命令は不要)、データベースから削除することもできます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "This is required on any method which interacts with the database, in order to run the operations in a transaction."
-msgstr "これは、トランザクションで処理を実行するために、データベースとやりとりするすべてのメソッドで必要です。"
+msgstr "これは、トランザクション内で操作を実行するために、データベースと対話するすべてのメソッドで必要です。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Our first repository"
 msgstr "最初のリポジトリ"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "Now that we know how to create, update and delete our entities, let's see how we can query our database to find them,\n"
 "or even run delete queries."
-msgstr "エンティティの作成、更新、削除の方法がわかったところで、データベースにクエリを実行してエンティ ティを検索したり、削除クエリを実行したりする方法を見てみましょう。"
+msgstr "エンティティの作成、更新、削除の方法がわかったので、データベースをクエリしてエンティティを検索する方法や、削除クエリを実行する方法を見てみましょう。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "Because query operations do not belong on instances of our entities, we will place these operations on another type\n"
 "called a `Repository`, and because those queries are intimately tied with the entities they operate on, we recommend\n"
 "placing them on an interface nested in the entity:"
-msgstr "クエリ操作はエンティティのインスタンスには属さないため、これらの操作は `Repository` と呼ばれる別のタイプに配置します。クエリは操作対象となるエンティティと密接に結びついているため、エンティティにネストされたインタフェースに配置することをお勧めします："
+msgstr "クエリ操作はエンティティのインスタンスに属さないため、これらの操作は `Repository` と呼ばれる別の型に配置します。また、それらのクエリは操作対象のエンティティと密接に結びついているため、エンティティ内にネストされたインターフェースに配置することをお勧めします。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "A Hibernate with Panache repository is:"
-msgstr "Hibernate with Panacheリポジトリは以下のとおりです："
+msgstr "Panache を使用した Hibernate リポジトリは次のとおりです。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "An interface nested in the entity (though it could be a toplevel interface if you prefer)"
-msgstr "エンティティにネストされたインターフェイス (必要であれば、トップレベル・インターフェイスでも構いません)"
+msgstr "エンティティ内にネストされたインターフェース (ただし、好みに応じてトップレベルインターフェースでも構いません)"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Which extends the `PanacheRepository` interface, with the entity in question as type parameter"
-msgstr "`PanacheRepository` インターフェイスを拡張したもので、該当するエンティティを型パラメータとして持ちます。"
+msgstr "`PanacheRepository` インターフェースを拡張し、問題のエンティティを型パラメーターとして持つ"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "And contains query methods, annotated with either `@Find` or `@HQL` or even `@SQL` (for native queries), or\n"
 "`default` methods with implementation of queries"
-msgstr "そして、 `@Find` 、 `@HQL` 、あるいは `@SQL` （ネイティブクエリ用）、あるいは `default` （クエリの実装を持つメソッド）でアノテーションされたクエリメソッドが含まれています。"
+msgstr "そして、`@Find` または `@HQL`、あるいは `@SQL` (ネイティブクエリ用) のいずれかでアノテーションが付けられたクエリメソッド、またはクエリの実装を含む `default` メソッドが含まれる"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "You can use `@Find` methods to find single instances, or collections of entities, by using the parameters of the\n"
 "method to build a query. The Hibernate documentation has\n"
 "https://docs.jboss.org/hibernate/orm/7.1/introduction/html_single/Hibernate_Introduction.html#generated-finder-methods[all the information you need about this]."
-msgstr "`@Find` メソッドを使用すると、メソッドのパラメータを使用してクエリを構築することで、 単一のインスタンスやエンティティのコレクションを見つけることができます。Hibernate のドキュメントには link:https://docs.jboss.org/hibernate/orm/7.1/introduction/html_single/Hibernate_Introduction.html#generated-finder-methods[、これに関して必要な情報がすべて] 記載されています。"
+msgstr "`@Find` メソッドを使用して、メソッドのパラメーターでクエリを構築することにより、単一のインスタンスまたはエンティティのコレクションを検索できます。Hibernate ドキュメントには、 https://docs.jboss.org/hibernate/orm/7.1/introduction/html_single/Hibernate_Introduction.html#generated-finder-methods[これに関する必要なすべての情報] があります。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "A few common examples"
-msgstr "よくある例"
+msgstr "いくつかの一般的な例"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Finder methods may return collections of entities"
-msgstr "Finder メソッドはエンティティのコレクションを返すことがあります。"
+msgstr "ファインダーメソッドはエンティティのコレクションを返す場合があります"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Or generate `COUNT` queries"
-msgstr "または、 `COUNT` クエリを生成します。"
+msgstr "または `COUNT` クエリを生成する"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Or single entities, and any number of parameters which must all match the queried entities."
-msgstr "または、単一のエンティティ、およびクエリされたエンティティにすべて一致しなければならない任意の数のパラメータ。"
+msgstr "または単一のエンティティ、およびクエリ対象のエンティティすべてに一致する必要がある任意の数のパラメーター"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "Alternately, you can use `@HQL` or `@SQL` queries, which support HQL and SQL queries. Once again\n"
 "the Hibernate documentation has https://docs.jboss.org/hibernate/orm/7.1/introduction/html_single/Hibernate_Introduction.html#generated-query-methods[all the information you need]."
-msgstr "別の方法として、 `@HQL` または `@SQL` クエリを使用することもできます。 クエリは HQL および SQL クエリをサポートしています。繰り返しますが、Hibernateのドキュメントに link:https://docs.jboss.org/hibernate/orm/7.1/introduction/html_single/Hibernate_Introduction.html#generated-query-methods[必要な情報がすべて] 記載されています。"
+msgstr "あるいは、HQL および SQL クエリをサポートする `@HQL` または `@SQL` クエリを使用できます。繰り返しになりますが、Hibernate ドキュメントには https://docs.jboss.org/hibernate/orm/7.1/introduction/html_single/Hibernate_Introduction.html#generated-query-methods[必要なすべての情報] があります。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Query methods may return collections of entities"
-msgstr "クエリ・メソッドはエンティティのコレクションを返すことがあります。"
+msgstr "クエリメソッドはエンティティのコレクションを返す場合があります"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Or projections of a single column, even multiple columns with `Object[]` and `List<Object[]>` types"
-msgstr "あるいは、 `Object[]` および `List<Object[]>` 型を持つ単一列、複数列の投影。"
+msgstr "または単一カラムのプロジェクション、さらに `Object[]` および `List<Object[]>` 型を使用した複数カラムのプロジェクションも可能"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Queries can of course refer to method parameters."
-msgstr "クエリはもちろんメソッドのパラメータを参照することができます。"
+msgstr "クエリはもちろんメソッドのパラメーターを参照できます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "The beauty of generated finder and query methods is that they are type-checked at build time: they will be validated\n"
 "and guarantee that you did not make any typo in the entity names, their fields, the HQL/SQL syntax, or the name of\n"
 "their parameters."
-msgstr "生成されたfinderメソッドとクエリメソッドの優れた点はビルド時に型チェックされることです。これらはバリデートされ、エンティティの名前、フィールド、HQL/SQL構文、もしくはパラメーターの名前にタイプミスがないことを保証します。"
+msgstr "生成されたファインダーメソッドとクエリメソッドの利点は、ビルド時 に型チェックされることです。これにより、エンティティ名、そのフィールド、HQL/SQL 構文、またはパラメーター名に誤植がないことが検証され、保証されます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Using the repository"
 msgstr "リポジトリの使用"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Using the repository can be done by simply injecting it where you intend to use it:"
-msgstr "リポジトリを使用するには、使用する場所にリポジトリを注入するだけです："
+msgstr "リポジトリを使用するには、使用したい場所にインジェクトするだけです。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "Now, as an added benefit, you can also access the repository using a handy shortcut generated static method on the\n"
 "https://docs.jboss.org/hibernate/orm/7.1/introduction/html_single/Hibernate_Introduction.html#static-metamodel[generated Metamodel]\n"
 "of your entity, which is super useful for discovery of operations (just type `Cat_.repo().` and see all your methods)\n"
 "and to avoid making a detour outside of your method to add an injected field, such as in this startup code that\n"
 "will delete all your cats (don't do this in production!!):"
-msgstr "追加された利点として、 link:https://docs.jboss.org/hibernate/orm/7.1/introduction/html_single/Hibernate_Introduction.html#static-metamodel[生成された] エンティティの link:https://docs.jboss.org/hibernate/orm/7.1/introduction/html_single/Hibernate_Introduction.html#static-metamodel[メタモデル] 上で便利なショートカット生成された静的メソッドを使用してリポジトリにアクセスすることもできます。これは操作の発見 ( `Cat_.repo().` と入力するだけですべてのメソッドが表示されます) のためにとても便利で、注入されたフィールドを追加するためにメソッドの外に回り道をすることを避けることができます："
+msgstr "さらに、生成されたエンティティの https://docs.jboss.org/hibernate/orm/7.1/introduction/html_single/Hibernate_Introduction.html#static-metamodel[生成されたメタモデル] にある便利なショートカット生成静的メソッドを使用してリポジトリにアクセスすることもできます。これは、操作の発見に非常に役立ち (単に `Cat_.repo().` と入力してすべてのメソッドを確認する)、メソッドの外部でインジェクトされたフィールドを追加する回り道を避けるためにも便利です。この起動コードのように、すべての猫を削除する例があります (本番環境では行わないでください!!):"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "All the repositories you define as nested interfaces of your entity will be available under their generated metamodel\n"
 "class under accessor methods of the same name as the repository. This is strictly equivalent to injecting the repository\n"
 "type, and in fact uses CDI under the hood to look up the repository."
-msgstr "エンティティの入れ子インターフェースとして定義したすべてのリポジトリは、生成されたメタモデルクラスの下でリポジトリと同じ名前のアクセサメソッドで利用できるようになります。これは厳密にはリポジトリタイプを注入することと等価であり、実際にはCDIを使用してリポジトリを検索します。"
+msgstr "エンティティのネストされたインターフェースとして定義するすべてのリポジトリは、生成されたメタモデルクラスの、リポジトリと同じ名前のアクセサーメソッドの下で利用できます。これはリポジトリ型をインジェクトすることと厳密に同等であり、実際には内部で CDI を使用してリポジトリを検索します。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "The `PanacheRepository` super type"
-msgstr "`PanacheRepository` スーパータイプ"
+msgstr "`PanacheRepository` スーパークラス"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "Just like in previous versions of Hibernate ORM and Hibernate Reactive with Panache, the `PanacheRepository` type comes\n"
 "packed with most of the operations you need to work on your entity, such as, out of the box:"
-msgstr "以前のバージョンの Hibernate ORM や Hibernate Reactive with Panache と同様に、 `PanacheRepository` 型には、エンティティを操作するために必要なほとんどの操作が、そのまま搭載されています："
+msgstr "Hibernate ORM と Hibernate Reactive with Panache の以前のバージョンと同様に、`PanacheRepository` 型には、エンティティを操作するために必要なほとんどの操作がすぐに利用できるようになっています。例えば次のとおりです。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Non-type-safe queries"
-msgstr "型安全でないクエリ"
+msgstr "タイプセーフでないクエリ"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "With generated finder and query methods, as we've previously shown, everything is validated at build-time, but if\n"
 "you want to write non-type-safe queries, you can always use the provided methods of `PanacheRepository`:"
-msgstr "生成されたfinderメソッドとクエリメソッドでは、前に示したように、ビルド時にすべてが検証されますが、型安全でないクエリを書きたい場合は、 `PanacheRepository` の提供されたメソッドを使うことができます："
+msgstr "これまでに示したように、生成されたファインダーメソッドとクエリメソッドを使用すると、すべてがビルド時 に検証されますが、タイプセーフでないクエリを作成したい場合は、`PanacheRepository` が提供するメソッドをいつでも使用できます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "About entity identifiers"
 msgstr "エンティティ識別子について"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "In the example above, we extended the `PanacheEntity` type, and did not define any database identifier, that's\n"
 "because `PanacheEntity` comes with a default generated database identifier, so you don't have to worry about it. It\n"
 "does this by extending the `WithId.AutoLong` class, which provides a generated database identifier of type `Long`."
-msgstr "上の例では、 `PanacheEntity` 型を拡張し、データベース識別子を定義しませんでした。これは、 `PanacheEntity` にはデフォルトで生成されたデータベース識別子が付属しているためです。これは `WithId.AutoLong` クラスを拡張することで実現され、 `Long` 型の生成データベース識別子を提供します。"
+msgstr "上記の例では、`PanacheEntity` 型を拡張し、データベース識別子を定義しませんでした。これは、`PanacheEntity` がデフォルトで生成されるデータベース識別子を備えているため、それについて心配する必要がないためです。これは、`Long` 型の生成されたデータベース識別子を提供する `WithId.AutoLong` クラスを拡張することで実現されます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "You can choose to extend the `WithId.AutoString` for a `String` identifier, or `WithId.AutoUUID` for a `UUID`\n"
 "identifier, or even extend `WithId<IdType>` to automatically get an attribute of the form:"
-msgstr "`String` 識別子のために `WithId.AutoString` を拡張したり、 `UUID` 識別子のために `WithId.AutoUUID` を拡張したり、あるいは `WithId<IdType>` を拡張してフォームの属性を自動的に取得することもできます："
+msgstr "`String` 識別子には `WithId.AutoString` を、`UUID` 識別子には `WithId.AutoUUID` を拡張することもできますし、`WithId<IdType>` を拡張して次の形式の属性を自動的に取得することもできます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "Naturally, you can also provide your own database identifier explicitly and implement the `PanacheEntity.Managed`\n"
 "interface in your entity, as well as use the `PanacheRepository.Managed` interface for your repository, in order to\n"
 "specify you database identifier type:"
-msgstr "`PanacheRepository.Managed` 当然ながら、データベース識別子の型を指定するために、独自のデータベース識別子を明示的に提供し、 `PanacheEntity.Managed` インターフェイスをエンティティに実装することもできます："
+msgstr "もちろん、独自のデータベース識別子を明示的に指定し、エンティティで `PanacheEntity.Managed` インターフェースを実装し、リポジトリには `PanacheRepository.Managed` インターフェースを使用して、データベース識別子型を指定することもできます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "Here is a list of entity supertypes you can use and the ID type they provide, but keep in mind you do not have to\n"
 "extend any of these types if you define you own ID:"
-msgstr "以下は、使用できるエンティティ・スーパータイプの一覧と、それらが提供するIDタイプです。ただし、独自のIDを定義する場合は、これらのタイプを拡張する必要はないことを覚えておいてください："
+msgstr "使用できるエンティティのスーパークラスとその提供する ID 型のリストを次に示しますが、独自の ID を定義する場合はこれらの型のいずれかを拡張する必要がないことに注意してください。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "ID type"
-msgstr "IDタイプ"
+msgstr "ID 型"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Supertype"
 msgstr "スーパータイプ"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Shortcut type"
 msgstr "ショートカットタイプ"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`Long`"
 msgstr "`Long`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`WithId.AutoLong`"
 msgstr "`WithId.AutoLong`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`PanacheEntity`"
 msgstr "`PanacheEntity`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`UUID`"
 msgstr "`UUID`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`WithId.AutoUUID`"
 msgstr "`WithId.AutoUUID`"
 
@@ -359,8 +359,8 @@ msgstr "`WithId.AutoUUID`"
 msgid "`String`"
 msgstr "`String`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`WithId.String`"
 msgstr "`WithId.String`"
 
@@ -368,538 +368,538 @@ msgstr "`WithId.String`"
 msgid "`T`"
 msgstr "`T`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`WithId<Id>`"
 msgstr "`WithId<Id>`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Use stateless sessions"
-msgstr "ステートレス・セッションの使用"
+msgstr "ステートレスセッションの使用"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "Out of the box, your subtype of `PanacheEntity` will be managed by Hibernate ORM, and every change to the entity will\n"
 "be automatically sent to the database without requiring any explicit `update` operation."
-msgstr "すぐに、 `PanacheEntity` のサブタイプは Hibernate ORM によって管理され、エンティティへのすべての変更は、明示的な `update` 操作を必要とせずに、自動的にデータベースに送信されます。"
+msgstr "デフォルトでは、`PanacheEntity` のサブタイプは Hibernate ORM によって管理され、エンティティーに対するすべての変更は、明示的な `update` 操作を必要とせずに自動的にデータベースに送信されます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "If on the other hand, you wish to make every `update` operation explicit, then you need to use what Hibernate ORM calls\n"
 "a _stateless session_."
-msgstr "一方、 `update` の操作をすべて明示的に行いたい場合は、Hibernate ORMでいうところの _ステートレスセッションを_ 使用する必要があります。"
+msgstr "一方で、すべての `update` 操作を明示的にしたい場合は、Hibernate ORM が _ステートレスセッション_ と呼ぶものを使用する必要があります。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "In this case, you need to extend `WithId.AutoLong` (or any other ID class or provide your own ID), and implement\n"
 "the `PanacheEntity.Stateless` and `PanacheRepository.Stateless` interfaces:"
-msgstr "この場合、 `WithId.AutoLong` （または他のIDクラス、あるいは独自のID）を継承し、 `PanacheEntity.Stateless` と `PanacheRepository.Stateless` インターフェイスを実装する必要があります："
+msgstr "この場合、`WithId.AutoLong` (またはその他の ID クラス、あるいは独自の ID) を拡張し、`PanacheEntity.Stateless` および `PanacheRepository.Stateless` インターフェースを実装する必要があります。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "As you can see, your entity definition is exactly the same, besides the two interfaces. But now, your entities will\n"
 "not be _managed_, so every update operation has to be explicit:"
-msgstr "ご覧のように、2つのインターフェース以外、エンティティの定義はまったく同じです。しかし今、あなたのエンティティは _管理さ_ れないので、更新操作はすべて明示的に行わなければなりません："
+msgstr "ご覧のとおり、エンティティー定義は2つのインターフェースを除けばまったく同じです。しかし、これでエンティティーは _管理_ されなくなるため、すべての更新操作を明示的に行う必要があります。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "As you can see, the only differences with a managed entity are:"
-msgstr "お分かりのように、マネージド・エンティティとの違いはただひとつ："
+msgstr "ご覧のとおり、管理対象エンティティーとの唯一の違いは次のとおりです。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "Any change to the entity instance fields must be explicitly pushed to the database by calling `update()` either on\n"
 "the entity or its repository"
-msgstr "エンティティのインスタンス・フィールドへの変更は、エンティティまたはそのリポジトリで `update()` を呼び出して、明示的にデータベースにプッシュする必要があります。"
+msgstr "エンティティーインスタンスのフィールドに対する変更は、エンティティーまたはそのリポジトリーのいずれかで `update()` を呼び出すことで、明示的にデータベースにプッシュする必要があります。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "You need to call `insert()` instead of `persist()` to insert the entity in the database"
-msgstr "データベースにエンティティを挿入するには、 `persist()` の代わりに `insert()` を呼び出す必要があります。"
+msgstr "データベースにエンティティーを挿入するには、`persist()` の代わりに `insert()` を呼び出す必要があります。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Your session will be of type `StatelessSession` instead of `Session`."
-msgstr "セッションのタイプは `Session` ではなく `StatelessSession` になります。"
+msgstr "セッションの型は `Session` ではなく `StatelessSession` になります。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "But that's mostly it. Everything else stays the same, in particular for queries and how to obtain entities."
-msgstr "でも、ほとんどそれだけです。特にクエリーやエンティティの取得方法については。"
+msgstr "しかし、ほとんどそれだけです。特にクエリーやエンティティーの取得方法については、それ以外のすべては同じままです。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "If you're using stateless sessions, you can also use the <<Jakarta Data>> type of repositories."
-msgstr "ステートレス・セッションを使用している場合は、 <<Jakarta Data>> タイプのリポジトリも使用できます。"
+msgstr "ステートレスセッションを使用している場合、<<Jakarta Data>> 型のリポジトリーも使用できます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Let's get reactive"
-msgstr "反応的になりましょう"
+msgstr "リアクティブにしてみよう"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "You want to start using your entities in a reactive application? Let's start by importing Hibernate Reactive in your\n"
 "`pom.xml` as well as a data source for your database:"
-msgstr "リアクティブアプリケーションでエンティティの使用を開始したいですか？データベースのデータソースと同様に、 `pom.xml` で Hibernate Reactive をインポートすることから始めましょう："
+msgstr "リアクティブアプリケーションでエンティティーを使い始めたいですか？まずは `pom.xml` に Hibernate Reactive とデータベースのデータソースをインポートすることから始めましょう。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "You can use any of the xref:hibernate-reactive.adoc#hr-getting-started[supported reactive drivers]."
-msgstr "xref:hibernate-reactive.adoc#hr-getting-started[サポートされているリアクティブ・ドライバの] どれでも使用できます。"
+msgstr "xref:hibernate-reactive.adoc#hr-getting-started[サポートされているリアクティブドライバー] のいずれかを使用できます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "Make sure you configure your reactive datasource in your `application.properties` (although you don't have to in DEV\n"
 "mode: if you don't, a dev service will be provided for you):"
-msgstr "`application.properties` でリアクティブ・データソースを設定するようにしてください（DEVモードでは設定する必要はありません：）"
+msgstr "`application.properties` でリアクティブデータソースを設定してください (ただし、開発モードでは必須ではありません。設定しない場合、dev services が提供されます)。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Now, in your code, the only differences with a regular managed session entity are:"
-msgstr "さて、あなたのコードでは、通常のマネージド・セッション・エンティティーとの違いは、次のことだけです："
+msgstr "さて、コードでは、通常の管理対象セッションエンティティーとの唯一の違いは次のとおりです。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Your entity implements `PanacheEntity.Reactive`"
-msgstr "エンティティは `PanacheEntity.Reactive`"
+msgstr "エンティティーが `PanacheEntity.Reactive` を実装します。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Your repository extends `PanacheRepository.Reactive`"
-msgstr "リポジトリは `PanacheRepository.Reactive`"
+msgstr "リポジトリーが `PanacheRepository.Reactive` を拡張します。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "All the operations return a `Uni<T>` instead of `T`, which is the standard Mutiny reactive type"
-msgstr "すべての操作は、標準的なMutinyの反応型である `T` の代わりに `Uni<T>` を返します。"
+msgstr "すべての操作は、`T` の代わりに `Uni<T>` を返します。これは標準的な Mutiny リアクティブ型です。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "And now when you want to use your entity or its repository, besides using `@WithTransaction` in place of\n"
 "`@Transactional`, you have to compose operations as you normally do in reactive code with Mutiny, but the operations are\n"
 "exactly the same otherwise:"
-msgstr "そして、エンティティやそのリポジトリを使用したい場合、 `@Transactional` の代わりに `@WithTransaction` を使用する以外に、Mutiny を使用してリアクティブ・コードで通常行うように操作を組み合わせる必要がありますが、それ以外の操作はまったく同じです："
+msgstr "そして、エンティティーまたはそのリポジトリーを使用したい場合、`@Transactional` の代わりに `@WithTransaction` を使用する以外は、Mutiny を使用するリアクティブコードで通常行うように操作を構成する必要がありますが、それ以外は操作はまったく同じです。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Reactive and stateless"
-msgstr "リアクティブでステートレス"
+msgstr "リアクティブかつステートレス"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "If you want to manage manually your entity changes, then you can use a stateless session by switching to\n"
 "the `PanacheEntity.Reactive.Stateless` for your entity, and `PanacheRepository.Reactive.Stateless`:"
-msgstr "エンティティの変更を手動で管理したい場合は、ステートレス・セッションを使用して、エンティティの `PanacheEntity.Reactive.Stateless` に切り替えて、 `PanacheRepository.Reactive.Stateless` ："
+msgstr "エンティティーの変更を手動で管理したい場合は、エンティティーに `PanacheEntity.Reactive.Stateless` を、リポジトリーに `PanacheRepository.Reactive.Stateless` を使用することで、ステートレスセッションを使用できます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "And for your usage code, the only change is the standard use of manually calling `update()`, and using `insert()`\n"
 "instead of `persist()`:"
-msgstr "また、使用コードについては、手動で `update()` を呼び出すという標準的な使い方と、 `persist()` の代わりに `insert()` を使うという変更だけです："
+msgstr "そして、使用するコードについて言えば、唯一の変更点は、`update()` を手動で呼び出す標準的な使用方法と、`persist()` の代わりに `insert()` を使用することです。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Combining blocking, reactive, managed, stateless code"
-msgstr "ブロッキング、リアクティブ、マネージド、ステートレスコードの組み合わせ"
+msgstr "ブロッキング、リアクティブ、管理、ステートレスなコードの組み合わせ"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "Let's say you want to use an entity in a blocking managed session code, but also in a reactive stateless code: this\n"
 "is possible no matter which supertype of your entity you picked. You should pick the supertype that represents your\n"
 "majority of use-cases, but any one you pick, you can always obtain the alternative operations by using the\n"
 "`.statelessReactive()` method on the entity:"
-msgstr "例えば、あるエンティティをブロッキングするマネージドセッションのコードで使いたいが、リアクティブなステートレスのコードでも使いたいとします。しかし、どのスーパータイプを選んでも、エンティティの `.statelessReactive()` メソッドを使用することで、常に代替操作を取得することができます："
+msgstr "エンティティーをブロッキング管理セッションコードと、リアクティブステートレスコードの両方で使用したいとしましょう。これは、エンティティーのどのスーパータイプを選択しても可能です。ほとんどのユースケースを表すスーパータイプを選択すべきですが、どれを選んだとしても、エンティティーで `.statelessReactive()` メソッドを使用することで、常に代替操作を取得できます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "All the alternative entity operations are available from these methods:"
-msgstr "これらのメソッドでは、すべての代替エンティティ操作が可能です："
+msgstr "代替のエンティティー操作はすべて、これらのメソッドから利用できます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Session type"
-msgstr "セッションタイプ"
+msgstr "セッション型"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Entity accessor"
-msgstr "エンティティアクセサリ"
+msgstr "エンティティーアクセサー"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Equivalent entity type"
-msgstr "同等のエンティティタイプ"
+msgstr "同等のエンティティー型"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`Session`"
 msgstr "`Session`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`.managedBlocking()`"
 msgstr "`.managedBlocking()`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`PanacheEntity.Managed`"
 msgstr "`PanacheEntity.Managed`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`StatelessSession`"
 msgstr "`StatelessSession`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`.statelessBlocking()`"
 msgstr "`.statelessBlocking()`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`PanacheEntity.Stateless`"
 msgstr "`PanacheEntity.Stateless`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`Mutiny.Session`"
 msgstr "`Mutiny.Session`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`.managedReactive()`"
 msgstr "`.managedReactive()`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`PanacheEntity.Reactive`"
 msgstr "`PanacheEntity.Reactive`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`Mutiny.StatelessSession`"
 msgstr "`Mutiny.StatelessSession`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`.statelessReactive()`"
 msgstr "`.statelessReactive()`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`PanacheEntity.Reactive.Stateless`"
 msgstr "`PanacheEntity.Reactive.Stateless`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "Similarly, for all the repository operations, you can obtain alternate repositories for your entity from the\n"
 "generated metamodel accessors, or by injecting them with `@Inject`:"
-msgstr "同様に、すべてのリポジトリ操作について、生成されたメタモデルアクセサから、または `@Inject` で注入することで、エンティティの代替リポジトリを取得できます："
+msgstr "同様に、すべてのリポジトリ操作に対して、生成されたメタモデルアクセサーからエンティティの代替リポジトリを取得したり、`@Inject` でそれらを注入したりできます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Metamodel accessor"
-msgstr "メタモデルアクセッサ"
+msgstr "メタモデルアクセサー"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Repository type"
-msgstr "リポジトリタイプ"
+msgstr "リポジトリの型"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`Cat_.managedBlocking()`"
 msgstr "`Cat_.managedBlocking()`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`PanacheRepository.Managed<Cat, Long>`"
 msgstr "`PanacheRepository.Managed<Cat, Long>`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`Cat_.statelessBlocking()`"
 msgstr "`Cat_.statelessBlocking()`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`PanacheRepository.Stateless<Cat, Long>`"
 msgstr "`PanacheRepository.Stateless<Cat, Long>`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`Cat_.managedReactive()`"
 msgstr "`Cat_.managedReactive()`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`PanacheRepository.Reactive<Cat, Long>`"
 msgstr "`PanacheRepository.Reactive<Cat, Long>`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`Cat_.statelessReactive()`"
 msgstr "`Cat_.statelessReactive()`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`PanacheRepository.Reactive.Stateless<Cat, Long>`"
 msgstr "`PanacheRepository.Reactive.Stateless<Cat, Long>`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "But you can also define any number of repositories for your custom operations within your entity:"
-msgstr "しかし、エンティティ内のカスタム操作のために、いくつでもリポジトリを定義することもできます："
+msgstr "しかし、エンティティ内でカスタム操作のための任意の数のリポジトリを定義することもできます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "And then you can inject both types of repositories:"
-msgstr "そして、両方のタイプのリポジトリを注入することができます："
+msgstr "そして、両方のタイプのリポジトリを注入することができます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "you can of course also use the generated metamodel accessors instead of injecting these repositories, with\n"
 "`Cat_.repo()` and `Cat_.theOtherRepo()`."
-msgstr "もちろん、これらのリポジトリを注入する代わりに、 `Cat_.repo()` と `Cat_.theOtherRepo()` を使って、生成されたメタモデルアクセサを使うこともできます。"
+msgstr "これらのリポジトリを注入する代わりに、`Cat_.repo()` と `Cat_.theOtherRepo()` を使用して、生成されたメタモデルアクセサーを使用することももちろん可能です。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Recap"
-msgstr "総括"
+msgstr "要約"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "Here is a table listing all the options you have for your entity and repository supertypes, depending on which\n"
 "model of operation you prefer, and which ID type you want. Remember you don't have to extend `WithId<Id>` if you\n"
 "define your own ID entity field:"
-msgstr "ここでは、どの操作モデルを使用するか、どの ID タイプを使用するかによって、エンティティやリポジトリのスーパータイプにどのようなオプションがあるかを一覧にしています。独自の ID エンティティフィールドを定義する場合、 `WithId<Id>` を拡張する必要がないことを覚えておいてください："
+msgstr "ここに、操作モデルの好みと必要な ID の型に応じて、エンティティおよびリポジトリのスーパータイプとして利用できるすべてのオプションをリストした表があります。独自の ID エンティティフィールドを定義する場合、`WithId<Id>` を拡張する必要がないことを覚えておいてください。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Entity superclass"
-msgstr "エンティティ・スーパークラス"
+msgstr "エンティティの親クラス"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Entity superinterface"
-msgstr "エンティティ・スーパーインターフェース"
+msgstr "エンティティの親インターフェース"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Repository supertype"
 msgstr "リポジトリのスーパータイプ"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`Session` (managed, blocking)"
 msgstr "`Session` (マネージド、ブロッキング)"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`PanacheRepository<Entity>`"
 msgstr "`PanacheRepository<Entity>`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`Id`"
 msgstr "`Id`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`PanacheRepository.Managed<Entity, Id>`"
 msgstr "`PanacheRepository.Managed<Entity, Id>`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`StatelessSession` (stateless, blocking)"
-msgstr "`StatelessSession` (ステートレス、ブロッキング）"
+msgstr "`StatelessSession` (ステートレス、ブロッキング)"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`PanacheRepository.Stateless<Entity, Id>`"
 msgstr "`PanacheRepository.Stateless<Entity, Id>`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`Mutiny.Session` (managed, reactive)"
 msgstr "`Mutiny.Session` (マネージド、リアクティブ)"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`PanacheRepository.Reactive<Entity, Id>`"
 msgstr "`PanacheRepository.Reactive<Entity, Id>`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`Mutiny.StatelessSession` (stateless, reactive)"
-msgstr "`Mutiny.StatelessSession` (ステートレス、リアクティブ）"
+msgstr "`Mutiny.StatelessSession` (ステートレス、リアクティブ)"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "`PanacheRepository.Reactive.Stateless<Entity, Id>`"
 msgstr "`PanacheRepository.Reactive.Stateless<Entity, Id>`"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Startup code"
 msgstr "起動コード"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "For blocking operations, invoking startup code is pretty trivial:"
-msgstr "ブロック操作の場合、起動コードを呼び出すのは非常に簡単です："
+msgstr "ブロッキング操作の場合、起動コードの呼び出しは非常に簡単です。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "For reactive operations, it is fairly similar:"
-msgstr "リアクティブ・オペレーションについても、ほぼ同様です："
+msgstr "リアクティブ操作の場合も同様です。"
 
 #: _guides/hibernate-panache-next.adoc
 msgid "Jakarta Data"
 msgstr "Jakarta Data"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Naturally, you can also use link:{jakarta-data-spec-url}[Jakarta Data] to define your repositories. For this you need to import the module:"
-msgstr "もちろん、 link:{jakarta-data-spec-url}[Jakarta Dataを使って] リポジトリを定義することもできます。そのためにはモジュールをインポートする必要があります："
+msgstr "当然ながら、link:{jakarta-data-spec-url}[Jakarta Data] を使用してリポジトリを定義することもできます。そのためには、以下のモジュールをインポートする必要があります。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "And then you can write your entity as described before, extending a variant of `PanacheEntity` or not, as you wish."
-msgstr "そして、 `PanacheEntity` のバリアントを拡張したり、拡張しなかったりしながら、先に説明したようにエンティティを書くことができます。"
+msgstr "その後、前に説明したように、`PanacheEntity` のバリアントを拡張するかどうかにかかわらず、必要に応じてエンティティを記述できます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "As for the repositories, given that Jakarta Data 1.0 only supports the stateless variants (managed entities are\n"
 "being added to the upcoming 1.1 version), we recommend that you stick to the `PanacheRepository` variants in order\n"
 "to support stateless or managed entities. Both blocking and reactive variants are supported, though."
-msgstr "リポジトリに関しては、Jakarta Data 1.0はステートレス・バリアントしかサポートしていないので（マネージド・エンティティは次期1.1バージョンで追加されます）、ステートレスまたはマネージド・エンティティをサポートするために `PanacheRepository` 。ブロッキング型もリアクティブ型もサポートされています。"
+msgstr "リポジトリについては、Jakarta Data 1.0 がステートレスなバリアントのみをサポートしているため（マネージドエンティティは次期 1.1 バージョンに追加される予定です）、ステートレスまたはマネージドエンティティをサポートするために `PanacheRepository` バリアントを使用することをお勧めします。ただし、ブロッキングおよびリアクティブの両方のバリアントがサポートされています。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "Otherwise, just replace `@HQL` with `@Query` and change the package import of `@Find`, and you can even write\n"
 "`@Delete` finder methods:"
-msgstr "そうでなければ、 `@HQL` を `@Query` に置き換えて、 `@Find` のパッケージのインポートを変更するだけで、 `@Delete` のファインダー・メソッドを書くこともできます："
+msgstr "そうでない場合は、`@HQL` を `@Query` に置き換え、`@Find` のパッケージインポートを変更するだけで、`@Delete` ファインダーメソッドを作成することもできます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "This is a regular finder method"
-msgstr "これは通常のファインダー方式です。"
+msgstr "これは通常のファインダーメソッドです"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Use `@Query` in place of `@HQL`, they're the same everything"
-msgstr "`@HQL` の代わりに `@Query` を使ってください。"
+msgstr "`@HQL` の代わりに `@Query` を使用します。これらはすべて同じです。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "You can write `delete` finder methods. Just like finder methods, except their action is to delete entities, optionally\n"
 "returning how many were deleted."
-msgstr "`delete` finderメソッドを書くことができます。finderメソッドと同じように、エンティティを削除します。"
+msgstr "`delete` ファインダーメソッドを記述できます。これはファインダーメソッドと似ていますが、そのアクションはエンティティを削除することであり、オプションで削除された数を返します。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "You can always explicitly write delete methods as query methods."
-msgstr "削除メソッドは、常に明示的にクエリ・メソッドとして記述することができます。"
+msgstr "削除メソッドは常にクエリメソッドとして明示的に記述できます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "But otherwise you can still make your entity extend `PanacheEntity` or any of its variants, and you still get\n"
 "your repository injectable, or via the `Cat_.repo()` accessor."
-msgstr "しかし、そうでなければ、 `PanacheEntity` やその亜種を拡張したエンティティを作成し、リポジトリをインジェクタで取得したり、 `Cat_.repo()` アクセサで取得したりすることができます。"
+msgstr "しかし、それ以外の場合でも、エンティティを `PanacheEntity` またはそのバリアントのいずれかを拡張させることができ、リポジトリを注入したり、`Cat_.repo()` アクセサーを介して取得したりすることができます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "Please refer to the corresponding https://hibernate.org/repositories/[Hibernate Data Repositories]\n"
 "and link:{jakarta-data-spec-url}[Jakarta Data]\n"
 "guides to learn what else they have to offer."
-msgstr "対応する link:https://hibernate.org/repositories/[Hibernate Data Repositoriesと] link:{jakarta-data-spec-url}[Jakarta Dataの] ガイドを参照してください。"
+msgstr "これらの機能の詳細については、対応する https://hibernate.org/repositories/[Hibernate Data Repositories] および link:{jakarta-data-spec-url}[Jakarta Data] ガイドを参照してください。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "You can also use the reactive variants by returning `Uni` types from your repository methods, or add other\n"
 "types of repositories in your entity to support managed entities."
-msgstr "また、リポジトリメソッドから `Uni` 型を返すことで、リアクティブバリアントを使用したり、エンティティに他のタイプのリポジトリを追加して、マネージドエンティティをサポートすることもできます。"
+msgstr "リポジトリメソッドから `Uni` 型を返すことでリアクティブなバリアントを使用することもできますし、マネージドエンティティをサポートするために、エンティティに他のタイプのリポジトリを追加することもできます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "You can also use <<Use stateless sessions,Panache Stateless repositories>> or\n"
 "<<Reactive and stateless,Panache Stateless Reactive repositories>>."
-msgstr "xref:Use stateless sessions[Panache Stateless リポジトリ] または xref:Reactive and stateless[Panache Stateless Reactive リポジトリを] 使用することもできます。"
+msgstr "<<Use stateless sessions,Panache ステートレスリポジトリ>> または <<Reactive and stateless,Panache ステートレスリアクティブリポジトリ>> を使用することもできます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "HQL, JD-QL, Jakarta-QL, Panache-QL"
 msgstr "HQL, JD-QL, Jakarta-QL, Panache-QL"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "There are different query languages used in this API:"
-msgstr "このAPIで使用されるクエリー言語はさまざまです："
+msgstr "この API では、異なるクエリ言語が使用されています。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "The link:https://docs.hibernate.org/orm/{hibernate-orm-version-major-minor}/querylanguage/html_single/[Hibernate Query Language] (HQL),\n"
 "which is the query language used by Hibernate, supported by the `@HQL` annotation."
-msgstr "link:https://docs.hibernate.org/orm/{hibernate-orm-version-major-minor}/querylanguage/html_single/[Hibernate Query Language] (HQL) は、Hibernate で使用されるクエリー言語で、 `@HQL` アノテーションでサポートされています。"
+msgstr "link:https://docs.hibernate.org/orm/{hibernate-orm-version-major-minor}/querylanguage/html_single/[Hibernate Query Language] (HQL) は、Hibernate で使用されるクエリ言語であり、`@HQL` アノテーションによってサポートされます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "The link:{jakarta-persistence-spec-url}#a4665[Jakarta Persistence Query Language] (JP-QL), which is a subset of the Hibernate\n"
 "Query Language. It is currently being moved to its own spec called\n"
 "link:https://jakarta.ee/specifications/query/1.0/jakarta-query-1.0-m1[Jakarta Query]."
-msgstr "link:{jakarta-persistence-spec-url}#a4665[Jakarta Persistence Query Language] （JP-QL）は、Hibernate Query Languageのサブセットです。現在、 link:https://jakarta.ee/specifications/query/1.0/jakarta-query-1.0-m1[Jakarta Queryという] 独自の仕様に移行しています。"
+msgstr "link:{jakarta-persistence-spec-url}#a4665[Jakarta Persistence Query Language] (JP-QL) は、Hibernate Query Language のサブセットです。これは現在、link:https://jakarta.ee/specifications/query/1.0/jakarta-query-1.0-m1[Jakarta Query] と呼ばれる独自の仕様に移行中です。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "The link:{jakarta-data-spec-url}#_jakarta_data_query_language[Jakarta Data Query Language] (JD-QL), which is a subset of the\n"
 "Jakarta Persistence Query Language, supported by the `@Query` annotation."
-msgstr "link:{jakarta-data-spec-url}#_jakarta_data_query_language[Jakarta Data Query Language] (JD-QL) は、Jakarta Persistence Query Language のサブセットで、 `@Query` アノテーションでサポートされています。"
+msgstr "link:{jakarta-data-spec-url}#_jakarta_data_query_language[Jakarta Data Query Language] (JD-QL) は、Jakarta Persistence Query Language のサブセットであり、`@Query` アノテーションによってサポートされます。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "The Panache Query Language, which is a superset of the Hibernate Query Language adding very few shortcuts, which\n"
 "is supported in all the `PanacheRepository` queries."
-msgstr "Panacheクエリ言語は、Hibernateクエリ言語のスーパーセットで、ごくわずかなショートカットが追加されており、すべての `PanacheRepository` クエリでサポートされています。"
+msgstr "Panache Query Language は、Hibernate Query Language のスーパーセットであり、ごくわずかなショートカットを追加したもので、すべての `PanacheRepository` クエリでサポートされています。"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid "Panache Query Language"
 msgstr "Panache クエリー言語"
 
+#. mt: gemini
 #: _guides/hibernate-panache-next.adoc
-#, fuzzy
 msgid ""
 "Normally, most HQL queries are of this form: `from EntityName [where ...] [order by ...]`, with optional elements\n"
 "at the end."
-msgstr "通常、ほとんどのHQLクエリはこの形式です： `from EntityName [where …​] [order by …​]` 最後にオプションの要素があります。"
+msgstr "通常、ほとんどのHQLクエリは、`from EntityName [where ...] [order by ...]` という形式で、最後にオプションの要素が続きます。"
 
 #: _guides/hibernate-panache-next.adoc
 msgid "If your select query does not start with `from`, `select` or `with`, we support the following additional forms:"

--- a/l10n/po/ja_JP/_guides/hibernate-reactive-panache.adoc.po
+++ b/l10n/po/ja_JP/_guides/hibernate-reactive-panache.adoc.po
@@ -13,7 +13,7 @@ msgstr ""
 #: _guides/hibernate-reactive-panache.adoc
 #, no-wrap
 msgid "Simplified Hibernate Reactive with Panache"
-msgstr "PanacheでシンプルになったHibernate Reactive"
+msgstr "Panache でシンプルになった Hibernate Reactive"
 
 #: _guides/hibernate-reactive-panache.adoc
 msgid ""

--- a/l10n/po/ja_JP/_guides/mongodb-panache-kotlin.adoc.po
+++ b/l10n/po/ja_JP/_guides/mongodb-panache-kotlin.adoc.po
@@ -13,7 +13,7 @@ msgstr ""
 #: _guides/mongodb-panache-kotlin.adoc
 #, no-wrap
 msgid "Simplified MongoDB with Panache and Kotlin"
-msgstr "シンプルになったMongoDB with PanacheとKotlin"
+msgstr "Panache と Kotlin でシンプルになった MongoDB"
 
 #: _guides/mongodb-panache-kotlin.adoc
 msgid ""

--- a/l10n/po/ja_JP/_guides/mongodb-panache.adoc.po
+++ b/l10n/po/ja_JP/_guides/mongodb-panache.adoc.po
@@ -13,7 +13,7 @@ msgstr ""
 #: _guides/mongodb-panache.adoc
 #, no-wrap
 msgid "Simplified MongoDB with Panache"
-msgstr "シンプルになったMongoDB with Panache"
+msgstr "Panache でシンプルになった MongoDB"
 
 #. type: Plain text
 #: _guides/mongodb-panache.adoc


### PR DESCRIPTION
## Summary

- Retranslate `l10n/po/ja_JP/_guides/hibernate-panache-next.adoc.po` from main branch with heading note feature
- Fix title translations for all Panache-related documents to use consistent nominal phrase style (体言止め)

## Changes

### Retranslation
- hibernate-panache-next.adoc.po: Full retranslation with configurable heading notes

### Title fixes
- hibernate-panache-next.adoc.po: "Panache Next によってシンプルになった Hibernate"
- hibernate-orm-panache-kotlin.adoc.po: "Panache と Kotlin でシンプルになった Hibernate ORM"
- mongodb-panache.adoc.po: "Panache でシンプルになった MongoDB"
- mongodb-panache-kotlin.adoc.po: "Panache と Kotlin でシンプルになった MongoDB"
- hibernate-reactive-panache.adoc.po: "Panache でシンプルになった Hibernate Reactive"