### PR TITLE
Retranslate _guides/quarkus-reactive-architecture.adoc.po

### DIFF
--- a/l10n/po/ja_JP/_guides/quarkus-reactive-architecture.adoc.po
+++ b/l10n/po/ja_JP/_guides/quarkus-reactive-architecture.adoc.po
@@ -67,10 +67,10 @@ msgstr "伸縮性 (Elastic) - 変動する負荷に適応すること"
 msgid "Resilient - they handle failures gracefully"
 msgstr "回復性 (Resilient) - 障害をグレースフルに処理すること"
 
+#. mt: gemini
 #: _guides/quarkus-reactive-architecture.adoc
-#, fuzzy
 msgid "Asynchronous message passing - the components of a reactive system interact using messages"
-msgstr "非同期メッセージ・パッシング - リアクティブ・システムのコンポーネントは、メッセージを使って相互作用します。"
+msgstr "非同期メッセージパッシング - リアクティブシステムのコンポーネントがメッセージを使用して相互作用すること"
 
 #. type: Plain text
 #: _guides/quarkus-reactive-architecture.adoc


### PR DESCRIPTION
## Summary
- Retranslate fuzzy entries in `_guides/quarkus-reactive-architecture.adoc.po` with Gemini