### PR TITLE
Improve tsujiw: Replace curl with HttpClient and update to tsuji 0.8.13

### DIFF
--- a/config/application.yaml
+++ b/config/application.yaml
@@ -1,5 +1,5 @@
 tsuji:
-  jar: https://github.com/doc-l10n-kit/tsuji/releases/download/v0.8.12/tsuji.jar
+  jar: https://github.com/doc-l10n-kit/tsuji/releases/download/v0.8.13/tsuji.jar
 
   language:
     from: en

--- a/tsujiw
+++ b/tsujiw
@@ -1,5 +1,7 @@
 #!/usr/bin/java --source 11
 import java.io.*;
+import java.net.URI;
+import java.net.http.*;
 import java.nio.file.*;
 import java.util.*;
 
@@ -36,7 +38,7 @@ public class tsujiw {
      * Bootstrap version - used to load SmallRye Config
      * This JAR is downloaded once and reused
      */
-    private static final String BOOTSTRAP_VERSION = "0.8.12";
+    private static final String BOOTSTRAP_VERSION = "0.8.13";
 
     private static final String BOOTSTRAP_ENV_VAR = "TSUJIW_BOOTSTRAPPED";
     private static final String JVM_OPTS_ENV_VAR = "TSUJIW_JVM_OPTS";
@@ -171,6 +173,29 @@ public class tsujiw {
     }
 
     /**
+     * Resolve JAR path from URL
+     * For GitHub releases: vendor/tsuji/<version>/tsuji.jar
+     * For other URLs: vendor/tsuji/<hash>/tsuji.jar
+     */
+    private static String resolveJarPathFromUrl(String url) {
+        // Try to extract version from GitHub releases URL pattern
+        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("/releases/download/v([0-9.]+(?:-[a-zA-Z0-9.]+)?)/");
+        java.util.regex.Matcher matcher = pattern.matcher(url);
+
+        String directory;
+        if (matcher.find()) {
+            // GitHub releases: use version as directory name
+            directory = matcher.group(1);
+        } else {
+            // Other URLs: use hash as directory name
+            int hash = Math.abs(url.hashCode());
+            directory = String.valueOf(hash);
+        }
+
+        return "vendor/tsuji/" + directory + "/tsuji.jar";
+    }
+
+    /**
      * Resolve JAR path from URI
      * Supports:
      *   - file:///path/to/tsuji.jar (standard)
@@ -191,12 +216,7 @@ public class tsujiw {
 
         } else if (jarUri.startsWith("https://") || jarUri.startsWith("http://")) {
             // Download from URL
-            String fileName = jarUri.substring(jarUri.lastIndexOf('/') + 1);
-            if (!fileName.endsWith(".jar")) {
-                fileName = "tsuji-downloaded.jar";
-            }
-
-            String jarPath = "vendor/tsuji/" + fileName;
+            String jarPath = resolveJarPathFromUrl(jarUri);
 
             // Download if not exists
             if (!Files.exists(Paths.get(jarPath))) {
@@ -213,18 +233,26 @@ public class tsujiw {
     }
 
     /**
-     * Download JAR from URL
+     * Download JAR from URL using Java HttpClient
      */
     private static void downloadJarFromUrl(String url, String jarPath) throws Exception {
         System.err.println("Downloading tsuji.jar from " + url + "...");
         Files.createDirectories(Paths.get(jarPath).getParent());
 
-        ProcessBuilder pb = new ProcessBuilder("curl", "-L", "--fail", url, "-o", jarPath);
-        int exitCode = pb.inheritIO().start().waitFor();
+        HttpClient client = HttpClient.newBuilder()
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build();
 
-        if (exitCode != 0) {
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create(url))
+            .GET()
+            .build();
+
+        HttpResponse<Path> response = client.send(request, HttpResponse.BodyHandlers.ofFile(Paths.get(jarPath)));
+
+        if (response.statusCode() >= 400) {
             Files.deleteIfExists(Paths.get(jarPath));
-            throw new IOException("Failed to download tsuji.jar from " + url);
+            throw new IOException("Failed to download tsuji.jar from " + url + " (HTTP " + response.statusCode() + ")");
         }
 
         System.err.println("Successfully downloaded to " + jarPath);
@@ -234,7 +262,7 @@ public class tsujiw {
      * Ensure bootstrap JAR exists, download if needed
      */
     private static String ensureBootstrapJar() throws Exception {
-        String jarPath = "vendor/tsuji/tsuji-" + BOOTSTRAP_VERSION + ".jar";
+        String jarPath = "vendor/tsuji/" + BOOTSTRAP_VERSION + "/tsuji.jar";
 
         if (!Files.exists(Paths.get(jarPath))) {
             downloadJar(BOOTSTRAP_VERSION, jarPath);
@@ -244,23 +272,14 @@ public class tsujiw {
     }
 
     /**
-     * Download tsuji.jar from GitHub releases
+     * Download tsuji.jar from GitHub releases using Java HttpClient
      */
     private static void downloadJar(String version, String jarPath) throws Exception {
-        System.err.println("Downloading tsuji.jar version " + version + "...");
-        Files.createDirectories(Paths.get(jarPath).getParent());
-
         String url = "https://github.com/doc-l10n-kit/tsuji/releases/download/v"
             + version + "/tsuji.jar";
 
-        ProcessBuilder pb = new ProcessBuilder("curl", "-L", "--fail", url, "-o", jarPath);
-        int exitCode = pb.inheritIO().start().waitFor();
-
-        if (exitCode != 0) {
-            Files.deleteIfExists(Paths.get(jarPath));
-            throw new IOException("Failed to download tsuji.jar from " + url);
-        }
-
+        System.err.println("Downloading tsuji.jar version " + version + "...");
+        downloadJarFromUrl(url, jarPath);
         System.err.println("Successfully downloaded tsuji-" + version + ".jar");
     }
 


### PR DESCRIPTION
## Problem

tsujiw has three issues:

1. **External dependency on curl** - Requires curl to be installed on the system, which is not guaranteed on all platforms
2. **Using outdated tsuji version** - tsuji 0.8.12 lacks forward compatibility fix for unknown properties (causes validation errors with `tsuji.jar` property)
3. **Version conflicts in cache** - Downloaded JARs saved in flat structure, preventing multiple versions from coexisting

## Solution

### 1. Replace curl with Java HttpClient

Replaces `ProcessBuilder("curl", ...)` with `java.net.http.HttpClient` (available since Java 11).

### 2. Update to tsuji 0.8.13

tsuji 0.8.13 includes `smallrye.config.mapping.validate-unknown=false` which fixes SRCFG00050 validation errors when wrapper properties like `tsuji.jar` are present in configuration.

### 3. Use directory-based JAR caching

Uses directory structure to separate different JAR versions/sources:

**Before:**
```
vendor/tsuji/tsuji.jar (overwrites on update)
```

**After:**
```
vendor/tsuji/0.8.13/tsuji.jar (shared by bootstrap and target)
vendor/tsuji/0.8.12/tsuji.jar
vendor/tsuji/12345678/tsuji.jar (non-GitHub URL)
```

## Implementation

### HttpClient Changes

- Added `java.net.http.*` imports
- Replaced curl subprocess calls with `HttpClient.send()`
- Uses `HttpResponse.BodyHandlers.ofFile()` for streaming downloads
- Maintains redirect following with `HttpClient.Redirect.NORMAL`
- Improved error messages with HTTP status codes

### Version Update

- Updated bootstrap JAR version from 0.8.12 to 0.8.13
- Updated `config/application.yaml` to reference tsuji 0.8.13

### Directory-based Caching

- GitHub releases: `vendor/tsuji/<version>/tsuji.jar`
- Other URLs: `vendor/tsuji/<hash>/tsuji.jar`
- Regex pattern matches GitHub releases URLs: `/releases/download/vX.Y.Z/`
- Extracts version for directory name
- For non-GitHub URLs, uses URL hash as directory name
- Bootstrap and target share the same directory when versions match
- Downloads only once when versions match, saving disk space

## Breaking Changes

None.