### PR TITLE
Retranslate fuzzy messages in 10 guides

### DIFF
--- a/l10n/po/ja_JP/_guides/capabilities.adoc.po
+++ b/l10n/po/ja_JP/_guides/capabilities.adoc.po
@@ -229,7 +229,7 @@ msgid "`io.quarkus.resteasy.json.jsonb.client`"
 msgstr "`io.quarkus.resteasy.json.jsonb.client`"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/capabilities.adoc
-#, fuzzy
 msgid "Including any one of those extensions in an application will enable the RESTEasy JSON serializer. In case a build step needs to check whether the RESTEasy JSON serializer is already enabled in an application, instead of checking whether any of those capabilities is present, it could simply check whether an extension with the prefix `io.quarkus.resteasy.json` is present."
-msgstr "これらの拡張機能のいずれかをアプリケーションに含めると、RESTEasy JSON シリアライザが有効になります。ビルド・ステップでは、アプリケーションで RESTEasy JSON シリアライザがすでに有効になっているかどうかを確認する必要がある場合、これらの機能のいずれかが存在するかどうかを確認する代わりに、接頭辞 `io.quarkus.resteasy.json` を持つ拡張機能が存在するかどうかを単純に確認できます。"
+msgstr "これらのエクステンションのいずれかをアプリケーションに含めると、RESTEasy JSON シリアライザーが有効になります。ビルドステップで、RESTEasy JSON シリアライザーがアプリケーションで既に有効になっているかを確認する必要がある場合、それらの機能のいずれかが存在するかどうかを確認する代わりに、`io.quarkus.resteasy.json` というプレフィックスを持つエクステンションが存在するかどうかを単に確認することができます。"

--- a/l10n/po/ja_JP/_guides/context-propagation.adoc.po
+++ b/l10n/po/ja_JP/_guides/context-propagation.adoc.po
@@ -32,14 +32,14 @@ msgstr ""
 "Quarkusのエクステンションの多くは、適切に動作するためにコンテキストオブジェクトを必要とします：例えば、 xref:rest-json.adoc[Quarkus REST（旧RESTEasy Reactive）] 、 xref:cdi-reference.adoc[ArC] 、 xref:transaction.adoc[Transaction] などです。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/context-propagation.adoc
-#, fuzzy
 msgid ""
 "If you write reactive/async code, you have to cut your work into a pipeline of code blocks that get executed\n"
 "\"later\", and in practice after the method you defined them in has returned. As such, `try/finally` blocks\n"
 "as well as `ThreadLocal` variables stop working, because your reactive code gets executed in another thread,\n"
 "after the caller ran its `finally` block."
-msgstr "リアクティブ/非同期コードを書く場合、「後で」実行されるコードブロックのパイプラインに作業を分割する必要があります。そのため、 `try/finally` ブロックや `ThreadLocal` 変数が動作しなくなります。これは、呼び出し元が `finally` ブロックを実行した後に、リアクティブコードが別のスレッドで実行されるためです。"
+msgstr "リアクティブ/非同期コードを書く場合、「後で」実行されるコードブロックのパイプラインに作業を切り込まなければならず、実際には、定義したメソッドがreturnされた後に実行されます。そのため、 `try/finally` ブロックや `ThreadLocal` 変数は動作しなくなります。なぜならば、呼び出し元が `finally` ブロックを実行した後に、リアクティブコードは別のスレッドで実行されるからです。"
 
 #. type: Plain text
 #: _guides/context-propagation.adoc

--- a/l10n/po/ja_JP/_guides/deploying-to-openshift.adoc.po
+++ b/l10n/po/ja_JP/_guides/deploying-to-openshift.adoc.po
@@ -25,12 +25,12 @@ msgstr ""
 "Quarkusは、正常なデフォルトとユーザーが提供する設定に基づいて{openshift}リソースを自動的に生成する機能を提供します。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/deploying-to-openshift.adoc
-#, fuzzy
 msgid ""
 "As an application developer, you can deploy your {project-name} applications to {openshift-long}.\n"
 "The `quarkus-openshift` extension provides this functionality, which supports multiple deployment options:"
-msgstr "アプリケーション開発者として、{project-name} アプリケーションを {openshift-long} にデプロイすることができます。 `quarkus-openshift` 拡張はこの機能を提供し、複数のデプロイオプションをサポートします："
+msgstr "アプリケーション開発者として、{project-name} アプリケーションを {openshift-long} にデプロイできます。`quarkus-openshift` エクステンションは、この機能を提供し、複数のデプロイオプションをサポートしています。"
 
 #. type: Plain text
 #: _guides/deploying-to-openshift.adoc
@@ -107,10 +107,10 @@ msgid "This strategy uses a JAR file as input to the S2I build process, which sp
 msgstr "このストラテジーでは、S2Iビルドプロセスの入力としてJARファイルを使用し、アプリケーションのビルドとデプロイをスピードアップします。"
 
 #. type: Title ==
+#. mt: gemini
 #: _guides/deploying-to-openshift.adoc
-#, fuzzy
 msgid "Supported build strategies"
-msgstr "サポートされるビルド戦略"
+msgstr "サポートされるビルドストラテジー"
 
 #. type: Plain text
 #: _guides/deploying-to-openshift.adoc
@@ -174,12 +174,12 @@ msgid "Bootstrapping the project"
 msgstr "プロジェクトのブートストラップ"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/deploying-to-openshift.adoc
-#, fuzzy
 msgid ""
 "First, you need a new project that contains the OpenShift extension.\n"
 "Then, before you build and deploy your application, you must log into an OpenShift cluster."
-msgstr "まず、OpenShift エクステンションを含む新しいプロジェクトが必要です。そして、アプリケーションをビルドしてデプロイする前に、OpenShift クラスタにログインする必要があります。"
+msgstr "まず、OpenShift エクステンションを含む新しいプロジェクトが必要です。次に、アプリケーションをビルドしてデプロイする前に、OpenShift クラスターにログインする必要があります。"
 
 #. type: Title ==
 #: _guides/deploying-to-openshift.adoc

--- a/l10n/po/ja_JP/_guides/dev-services.adoc.po
+++ b/l10n/po/ja_JP/_guides/dev-services.adoc.po
@@ -154,12 +154,12 @@ msgid ""
 msgstr "データベース Dev Services は、アプリケーションにリアクティブ・データソースまたは JDBC データソースエクステンションが存在し、データベースの URL が設定されていない場合に有効になります。詳細については、 link:datasource.html#dev-services[データソース・ガイド]を参照してください。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/dev-services.adoc
-#, fuzzy
 msgid ""
 "Quarkus provides Dev Services for all databases it supports. Most of these are run in a container, except\n"
 "H2 which is run in-process. Dev Services are supported for both JDBC and reactive drivers."
-msgstr "Quarkusは、サポートしているすべてのデータベースに対してDev Servicesを提供しています。これらのほとんどはコンテナ内で実行されますが、H2はプロセス内で実行されます。Devサービスは、JDBCドライバとリアクティブドライバの両方に対応しています。"
+msgstr "Quarkus は、サポートしているすべてのデータベースに対して Dev Services を提供しています。これらのほとんどはコンテナー内で実行されますが、H2 はプロセス内で実行されます。Dev Services は、JDBC およびリアクティブドライバーの両方をサポートしています。"
 
 #. type: Plain text
 #: _guides/dev-services.adoc
@@ -230,12 +230,12 @@ msgid "LRA"
 msgstr "LRA"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/dev-services.adoc
-#, fuzzy
 msgid ""
 "The Narayana LRA Dev Service will be enabled when the `quarkus-narayana-lra` extension is present in your application, and the coordinator URL has not been explicitly configured. More information can be found in the\n"
 "xref:lra-dev-services.adoc[Narayana LRA Dev Services Guide]."
-msgstr "アプリケーションに `quarkus-narayana-lra` 拡張機能があり、コーディネーターの URL が明示的に設定されていない場合、Narayana LRA Dev Service が有効になります。詳細は『 xref:lra-dev-services.adoc[Narayana LRA Dev Services Guide] 』を参照してください。"
+msgstr "Narayana LRA Dev Service は、アプリケーションに `quarkus-narayana-lra` エクステンションが存在し、コーディネーター URL が明示的に設定されていない場合に有効になります。詳細は、 xref:lra-dev-services.adoc[Narayana LRA Dev Services Guide] を参照してください。"
 
 #. type: Title ==
 #: _guides/dev-services.adoc

--- a/l10n/po/ja_JP/_guides/hibernate-search-orm-elasticsearch.adoc.po
+++ b/l10n/po/ja_JP/_guides/hibernate-search-orm-elasticsearch.adoc.po
@@ -1230,25 +1230,25 @@ msgstr ""
 "を参照してください。"
 
 #. type: Title ==
+#. mt: gemini
 #: _guides/hibernate-search-orm-elasticsearch.adoc
-#, fuzzy
 msgid "Activate/deactivate Hibernate Search"
-msgstr "ハイバネート検索の有効化/無効化"
+msgstr "Hibernate Search のアクティブ化/非アクティブ化"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/hibernate-search-orm-elasticsearch.adoc
-#, fuzzy
 msgid ""
 "When a persistence unit is configured for Hibernate Search indexing at build time,\n"
 "Hibernate Search is active in that persistence unit by default.\n"
 "Quarkus starts Hibernate Search when the application starts."
-msgstr "ビルド時にHibernate Searchのインデックス作成用に永続性ユニットが設定されると、デフォルトでその永続性ユニットでHibernate Searchがアクティブになります。Quarkusは、アプリケーションの起動時にHibernate Searchを開始します。"
+msgstr "永続化ユニットがビルド時に Hibernate Search インデックス作成用に設定されている場合、その永続化ユニットでは、デフォルトで Hibernate Search がアクティブになります。アプリケーションの起動時に Quarkus が Hibernate Search を開始します。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/hibernate-search-orm-elasticsearch.adoc
-#, fuzzy
 msgid "To deactivate Hibernate Search in a given persistence unit at runtime, set `quarkus.hibernate-search-orm-elasticsearch[.optional name].active` to `false`. This works similarly to xref:hibernate-orm.adoc#persistence-unit-active[the corresponding feature of the Hibernate ORM extension], but for <<injecting-entry-points,Hibernate Search beans>>."
-msgstr "実行時に、指定した永続化ユニットで Hibernate Search を無効にするには、 `quarkus.hibernate-search-orm-elasticsearch[.optional name].active` を `false` に設定します。 これは、 xref:hibernate-orm.adoc#persistence-unit-active[Hibernate ORM 拡張の対応する] 機能と同様に動作しますが、 xref:injecting-entry-points[Hibernate Search Bean] 用です。"
+msgstr "実行時に特定の永続化ユニットで Hibernate Search を非アクティブ化するには、`quarkus.hibernate-search-orm-elasticsearch[.optional name].active` を `false` に設定します。これは xref:hibernate-orm.adoc#persistence-unit-active[Hibernate ORM エクステンションの対応する機能] と同様に機能しますが、<<injecting-entry-points,Hibernate Search Bean>> に適用されます。"
 
 #. type: Title =
 #: _guides/hibernate-search-orm-elasticsearch.adoc

--- a/l10n/po/ja_JP/_guides/jms.adoc.po
+++ b/l10n/po/ja_JP/_guides/jms.adoc.po
@@ -20,10 +20,10 @@ msgid "Using JMS"
 msgstr "JMSの使用"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/jms.adoc
-#, fuzzy
 msgid "<a class=\"status-label status-preview\" title=\"This extension's backward compatibility and presence in the ecosystem is not guaranteed\" href=\"#extension-status-note\">preview</a>"
-msgstr "<a class=\"status-label status-preview\" title=\"この拡張機能の下位互換性とエコシステム内での存在は保証されていません\" href=\"#extension-status-note\">プレビュー</a>"
+msgstr "<a class=\"status-label status-preview\" title=\"このエクステンションの後方互換性およびエコシステムにおける存在は保証されません\" href=\"#extension-status-note\">プレビュー</a>"
 
 #. type: Plain text
 #: _guides/jms.adoc
@@ -333,12 +333,12 @@ msgid ""
 msgstr "Artemis の接続プロパティーを設定する必要があります。これは `src/main/resources/application.properties` ファイルで行います。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/jms.adoc
-#, fuzzy
 msgid ""
 "The `quarkus.artemis.enabled` property is a build-time setting that must be set to `true` for the `ConnectionFactory` bean to be created.\n"
 "Without it, the extension will not produce a `ConnectionFactory` and injection will fail with an `UnsatisfiedResolutionException`."
-msgstr "`quarkus.artemis.enabled` プロパティはビルド時の設定で、 `ConnectionFactory` Bean を作成するには `true` に設定する必要があります。これがないと、拡張機能は `ConnectionFactory` を生成せず、注入は `UnsatisfiedResolutionException` で失敗します。"
+msgstr "`quarkus.artemis.enabled` プロパティーは、`ConnectionFactory` Bean が作成されるために `true` に設定する必要があるビルド時の設定です。これがないと、エクステンションは `ConnectionFactory` を生成せず、インジェクションは `UnsatisfiedResolutionException` で失敗します。"
 
 #. type: Plain text
 #: _guides/jms.adoc

--- a/l10n/po/ja_JP/_guides/platform.adoc.po
+++ b/l10n/po/ja_JP/_guides/platform.adoc.po
@@ -25,16 +25,16 @@ msgid "The Quarkus extension ecosystem consists of the Quarkus extensions develo
 msgstr "Quarkusエクステンションエコシステムは、Quarkusコア開発チームを含むコミュニティによって開発・保守されたQuarkusエクステンションで構成されています。Quarkusエコシステム（\"Quarkus universe\"と呼ばれることもあります）には、これまでに開発されたすべてのQuarkusエクステンションが含まれていますが、Quarkusプラットフォームという概念もあります。"
 
 #. type: Title =
+#. mt: gemini
 #: _guides/platform.adoc
-#, fuzzy
 msgid "What is the Quarkus Platform?"
-msgstr "Quarkusプラットフォームとは何ですか？"
+msgstr "Quarkusプラットフォームとは"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/platform.adoc
-#, fuzzy
 msgid "The Quarkus Platform is a curated set of extensions, tools, and configurations that make it easier to build, test, and deploy Java applications with Quarkus."
-msgstr "Quarkusプラットフォームは、Quarkusを使用してJavaアプリケーションを簡単にビルド、テスト、デプロイできるようにする、拡張機能、ツール、設定の厳選されたセットです。"
+msgstr "Quarkusプラットフォームは、QuarkusでJavaアプリケーションを構築、テスト、デプロイすることを容易にする、厳選されたエクステンション、ツール、設定のセットです。"
 
 #. type: Plain text
 #: _guides/platform.adoc
@@ -44,34 +44,34 @@ msgid ""
 msgstr "Quarkusプラットフォームの基本的な約束事は、プラットフォームで構成されるQuarkusエクステンションを組み合わせて、お互いに競合することなく同じアプリケーションで使用することができるということです。Quarkusプラットフォームを作成する各組織は、プラットフォームに受け入れられるエクステンションについて独自の基準を設定し、受け入れられたエクステンション間の互換性を保証する手段を確立することができます。"
 
 #. type: Title =
+#. mt: gemini
 #: _guides/platform.adoc
-#, fuzzy
 msgid "How does the Quarkus Platform help?"
-msgstr "Quarkusプラットフォームはどのように役立ちますか？"
+msgstr "Quarkusプラットフォームの利点"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/platform.adoc
-#, fuzzy
 msgid "When multiple extensions are used in the same project, a Quarkus platform BOM ensures:"
-msgstr "複数の拡張機能を同じプロジェクトで使用する場合、QuarkusプラットフォームのBOMが保証されます："
+msgstr "同じプロジェクトで複数のエクステンションを使用する場合、QuarkusプラットフォームのBOMは以下を保証します。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/platform.adoc
-#, fuzzy
 msgid "version compatibility between the dependencies;"
-msgstr "依存関係間のバージョンの互換性；"
+msgstr "依存関係間のバージョン互換性;"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/platform.adoc
-#, fuzzy
 msgid "simplified dependency management;"
-msgstr "依存関係の管理の簡素化；"
+msgstr "依存関係管理の簡素化;"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/platform.adoc
-#, fuzzy
 msgid "easier upgrades."
-msgstr "より簡単なアップグレード。"
+msgstr "アップグレードの容易化。"
 
 #. type: Title ==
 #: _guides/platform.adoc

--- a/l10n/po/ja_JP/_guides/vertx-reference.adoc.po
+++ b/l10n/po/ja_JP/_guides/vertx-reference.adoc.po
@@ -920,13 +920,13 @@ msgid "Use codecs"
 msgstr "コーデックの使用"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/vertx-reference.adoc
-#, fuzzy
 msgid ""
 "The link:++https://vertx.io/docs/vertx-core/java/#event_bus++[Vert.x Event Bus] uses link:++https://vertx.io/docs/vertx-core/java/#_message_codecs++[codecs] to _serialize_ and _deserialize_ message objects.\n"
 "Quarkus provides a default codec for local delivery.\n"
 "This codec is automatically used for return types and message body parameters of local consumers, i.e. methods annotated with `@ConsumeEvent` where `ConsumeEvent#local() == true` (which is the default)."
-msgstr "link:https://vertx.io/docs/vertx-core/java/#event_bus[Vert.x Event Busでは] 、 link:https://vertx.io/docs/vertx-core/java/#_message_codecs[コーデックを] 使用してメッセージオブジェクトの _シリアライズと_ _デシリアライズを_ 行います。Quarkusは、ローカル配信用のデフォルトのコーデックを提供します。 `ConsumeEvent#local() == true` このコーデックは、ローカル・コンシューマーのリターン・タイプやメッセージ・ボディのパラメータに自動的に使用されます。つまり、 `@ConsumeEvent` （デフォルト）でアノテーションされたメソッドです。"
+msgstr "link:++https://vertx.io/docs/vertx-core/java/#event_bus++[Vert.x イベントバス] は、link:++https://vertx.io/docs/vertx-core/java/#_message_codecs++[コーデック] を使用して、メッセージオブジェクトを _シリアライズ_ および _デシリアライズ_ します。Quarkus は、ローカル配信用のデフォルトのコーデックを提供します。このコーデックは、ローカルコンシューマーの戻り値の型とメッセージ本文パラメーター、つまり `@ConsumeEvent` アノテーションが付けられ、`ConsumeEvent#local() == true` （デフォルト）であるメソッドに自動的に使用されます。"
 
 #. type: Plain text
 #: _guides/vertx-reference.adoc

--- a/l10n/po/ja_JP/_guides/web.adoc.po
+++ b/l10n/po/ja_JP/_guides/web.adoc.po
@@ -151,16 +151,16 @@ msgid "Model-View-Controller (MVC)"
 msgstr "Model-View-Controller (MVC)"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/web.adoc
-#, fuzzy
 msgid "The MVC approach is also made very easy with Quarkus thanks to Qute."
-msgstr "Quarkusでは、QuteのおかげでMVCアプローチも非常に簡単です。"
+msgstr "MVC アプローチも、Qute のおかげで Quarkus で非常に簡単になりました。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/web.adoc
-#, fuzzy
 msgid "Associated with the https://docs.quarkiverse.io/quarkus-web-bundler/dev/[Web Bundler extension], the road is open to build modern web applications for all your needs."
-msgstr "link:https://docs.quarkiverse.io/quarkus-web-bundler/dev/[Web Bundlerエクステンションと] 連携することで、あらゆるニーズに対応するモダンなWebアプリケーションを構築する道が開けます。"
+msgstr "https://docs.quarkiverse.io/quarkus-web-bundler/dev/[Web Bundler エクステンション] と組み合わせることで、あらゆるニーズに対応するモダンな Web アプリケーションを構築する道が開かれます。"
 
 #. type: Block title
 #: _guides/web.adoc
@@ -168,10 +168,10 @@ msgid "src/main/java/rest/Todos.java"
 msgstr "src/main/java/rest/Todos.java"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/web.adoc
-#, fuzzy
 msgid "Check out https://www.youtube.com/watch?v=JNmHN5mK180[Quarkus Insights Episode #178]. You can also give it a try using https://github.com/quarkusio/quarkus-web-lab[the web-lab repo]."
-msgstr "link:https://www.youtube.com/watch?v=JNmHN5mK180[Quarkus Insights Episode #178を] ご覧ください。また、 link:https://github.com/quarkusio/quarkus-web-lab[Web-labのレポを使って] 試すこともできます。"
+msgstr "https://www.youtube.com/watch?v=JNmHN5mK180[Quarkus Insights エピソード #178] をご覧ください。また、 https://github.com/quarkusio/quarkus-web-lab[web-lab リポジトリ] を使って試すこともできます。"
 
 #. type: Title =
 #: _guides/web.adoc

--- a/l10n/po/ja_JP/_guides/websockets.adoc.po
+++ b/l10n/po/ja_JP/_guides/websockets.adoc.po
@@ -11,32 +11,32 @@ msgstr ""
 "X-Generator: Poedit 3.3.2\n"
 
 #. type: YAML Front Matter: title
+#. mt: gemini
 #: _guides/websockets.adoc
-#, fuzzy
 msgid "Using WebSockets with Undertow"
-msgstr "UndertowでWebSocketを使用"
+msgstr "Undertow で WebSocket を使用する"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/websockets.adoc
-#, fuzzy
 msgid ""
 "This guide explains how your Quarkus application can utilize web sockets to create interactive web applications,\n"
 "in the context of an Undertow-based Quarkus application, or if you rely on https://jakarta.ee/specifications/websocket/[Jakarta WebSocket]."
-msgstr "このガイドでは、QuarkusアプリケーションでWebソケットを利用してインタラクティブなWebアプリケーションを作成する方法について、UndertowベースのQuarkusアプリケーション、または link:https://jakarta.ee/specifications/websocket/[Jakarta WebSocketを] 使用している場合を例に説明します。"
+msgstr "このガイドでは、Quarkus アプリケーションが Undertow ベースの Quarkus アプリケーションのコンテキストで、または https://jakarta.ee/specifications/websocket/[Jakarta WebSocket] に依存している場合に、Web ソケットを利用してインタラクティブな Web アプリケーションを作成する方法を説明します。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/websockets.adoc
-#, fuzzy
 msgid ""
 "If you don't use Undertow or https://jakarta.ee/specifications/websocket/[Jakarta WebSocket],\n"
 "it is recommended to use the more modern xref:websockets-next-tutorial.adoc[WebSockets Next extensions]."
-msgstr "Undertowまたは link:https://jakarta.ee/specifications/websocket/[Jakarta WebSocketを] 使用しない場合は、より最新の xref:websockets-next-tutorial.adoc[WebSockets Next拡張機能を] 使用することをお勧めします。"
+msgstr "Undertow または https://jakarta.ee/specifications/websocket/[Jakarta WebSocket] を使用しない場合は、よりモダンな xref:websockets-next-tutorial.adoc[WebSockets Next extension] の使用をお勧めします。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/websockets.adoc
-#, fuzzy
 msgid "Because it's the _canonical_ web socket application, we are going to create a simple chat application."
-msgstr "Webソケットアプリケーションの _定番_ なので、簡単なチャットアプリケーションを作成します。"
+msgstr "これは _canonical_ な Web ソケットアプリケーションなので、シンプルなチャットアプリケーションを作成します。"
 
 #. type: Title =
 #: _guides/websockets.adoc


### PR DESCRIPTION
## Summary

Retranslates fuzzy messages in 10 guides with the lowest fuzzy message counts using improved AsciidocMarkupValidator.

## Files Updated

From the bottom of the fuzzy message list:

1. dev-services.adoc.po
2. websockets.adoc.po
3. hibernate-search-orm-elasticsearch.adoc.po
4. context-propagation.adoc.po
5. platform.adoc.po
6. capabilities.adoc.po
7. deploying-to-openshift.adoc.po
8. jms.adoc.po
9. web.adoc.po
10. vertx-reference.adoc.po

## Changes

- 10 files changed, 54 insertions(+), 54 deletions(-)
- All fuzzy messages in these files have been retranslated and unfuzzied

## Validator Improvements

Uses tsuji with improved AsciidocMarkupValidator that:
- Detects when markup is incorrectly added to translations (e.g., backticks added to plain text like `pom.xml`)
- Prevents validation errors in both directions (missing markup and incorrectly added markup)