### PR TITLE
Retranslate fuzzy messages in 6 guides (batch 2)

### DIFF
--- a/l10n/po/ja_JP/_guides/_includes/smallrye-pulsar-consumer.adoc.po
+++ b/l10n/po/ja_JP/_guides/_includes/smallrye-pulsar-consumer.adoc.po
@@ -542,8 +542,8 @@ msgid "*cryptoFailureAction*"
 msgstr "*cryptoFailureAction*"
 
 #. type: Table
+#. mt: gemini
 #: _guides/_includes/smallrye-pulsar-consumer.adoc
-#, fuzzy
 msgid ""
 "Consumer should take action when it receives a message that can not be decrypted. +\n"
 "* **FAIL**: this is the default option to fail messages until crypto succeeds. +\n"
@@ -556,13 +556,16 @@ msgid ""
 "\n"
 "Delivered encrypted message contains `EncryptionContext` which contains encryption and compression information in it using which application can decrypt consumed message payload."
 msgstr ""
-"復号化できないメッセージを受信した場合、Consumerは以下のアクションを取る 必要があります。\n"
+"コンシューマーは、復号化できないメッセージを受信した場合にアクションを取るべきです。+\n"
+"* **FAIL**: これは、暗号化が成功するまでメッセージを失敗させるためのデフォルトのオプションです。+\n"
+"* **DISCARD**: 静かに確認応答し、アプリケーションにメッセージを配信しません。+\n"
+"* **CONSUME**: 暗号化されたメッセージをアプリケーションに配信します。メッセージを復号化するのはアプリケーションの責任です。\n"
 "\n"
-" * *FAIL* : cryptoが成功するまでメッセージを失敗させるデフォルトのオプション。\n"
+"メッセージの解凍が失敗します。\n"
 "\n"
-" * *DISCARD* : 静かに承認し、アプリケーションにメッセージを配信しません。\n"
+"メッセージにバッチメッセージが含まれている場合、クライアントはバッチ内の個々のメッセージを取得できません。\n"
 "\n"
-"** CONSUME* ：暗号化されたメッセージをアプリケーションに配信します。CONSUME: 暗号化されたメッセージをアプリケーションに配信します。"
+"配信された暗号化メッセージには `EncryptionContext` が含まれており、それには暗号化および圧縮情報が含まれています。アプリケーションはこれを使用して、消費されたメッセージペイロードを復号化できます。"
 
 #. type: Table
 #: _guides/_includes/smallrye-pulsar-consumer.adoc

--- a/l10n/po/ja_JP/_guides/ansible.adoc.po
+++ b/l10n/po/ja_JP/_guides/ansible.adoc.po
@@ -37,10 +37,10 @@ msgid "You'll need to https://docs.ansible.com/ansible/latest/installation_guide
 msgstr "ワークステーションに link:https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html[Ansibleをインストール] する必要があります。これが完了したら、次のコマンドでQuarkus専用のAnsible用エクステンションをインストールできます："
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/ansible.adoc
-#, fuzzy
 msgid "The Ansible collection we just installed only supports RHEL, Fedora, and other Linux distributions using RPMs. Ansible defines these as \"RedHat family\". Using the content on other platforms (Windows, Debian, Ubuntu, ...), while not impossible, will require a few adjustments."
-msgstr "先ほどインストールしたAnsibleコレクションは、RHEL、Fedora、およびRPMを使用するその他のLinuxディストリビューションのみをサポートしています。Ansibleはこれらを「RedHatファミリー」と定義しています。他のプラットフォーム（Windows、Debian、Ubuntu、...）でコンテンツを使用することは、不可能ではありませんが、いくつかの調整が必要です。"
+msgstr "今インストールした Ansible コレクションは、RHEL、Fedora、その他 RPM を使用する Linux ディストリビューションのみをサポートしています。Ansible はこれらを「RedHat family」と定義しています。他のプラットフォーム（Windows、Debian、Ubuntu など）でコンテンツを使用することは不可能ではありませんが、いくつかの調整が必要です。"
 
 #. type: Title ==
 #: _guides/ansible.adoc
@@ -138,10 +138,10 @@ msgid "Manually, you can also test if the app is reachable:"
 msgstr "手動で、アプリが到達可能かどうかをテストすることもできます："
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/ansible.adoc
-#, fuzzy
 msgid "We'll see how to automate those validations in the next and last part of this tutorial."
-msgstr "このチュートリアルの最後となる次のパートでは、これらのバリデーションを自動化する方法を説明します。"
+msgstr "このチュートリアルの最後となる次のパートでは、これらの検証を自動化する方法を見ていきましょう。"
 
 #. type: Title ==
 #: _guides/ansible.adoc
@@ -160,10 +160,10 @@ msgid "To run this playbook, you use again the ansible-playbook command, but pro
 msgstr "このプレイブックを実行するには、再びansible-playbookコマンドを使用しますが、今度はプレイブックへのパスを指定します："
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/ansible.adoc
-#, fuzzy
 msgid "You can also automate the validation part we mentioned in the previous section. You can use the https://docs.ansible.com/ansible/latest/collections/ansible/builtin/assert_module.html[ansible.builtin.assert] module and populate the https://docs.ansible.com/ansible/latest/collections/ansible/builtin/service_facts_module.html#examples[service facts] to ensure the systemd service of the Quarkus app is running, along with https://docs.ansible.com/ansible/latest/collections/ansible/builtin/uri_module.html[ansible.builtin.uri] to check that the Quarkus app is accessible."
-msgstr "前のセクションで説明した検証部分を自動化することもできます。 link:https://docs.ansible.com/ansible/latest/collections/ansible/builtin/assert_module.html[ansible.builtin.assert] モジュールを使用して、Quarkusアプリのsystemdサービスが実行されていることを確認するために link:https://docs.ansible.com/ansible/latest/collections/ansible/builtin/service_facts_module.html#examples[サービスファクトを] 入力し、 link:https://docs.ansible.com/ansible/latest/collections/ansible/builtin/uri_module.html[ansible.builtin.uriを] 使用してQuarkusアプリにアクセスできることを確認します。"
+msgstr "前のセクションで言及した検証部分も自動化できます。link:https://docs.ansible.com/ansible/latest/collections/ansible/builtin/assert_module.html[ansible.builtin.assert] モジュールを使用して、Quarkus アプリの systemd サービスが実行されていることを確認するために link:https://docs.ansible.com/ansible/latest/collections/ansible/builtin/service_facts_module.html#examples[サービスファクト] を入力し、さらに Quarkus アプリにアクセスできることを確認するために link:https://docs.ansible.com/ansible/latest/collections/ansible/builtin/uri_module.html[ansible.builtin.uri] を使用できます。"
 
 #. type: Plain text
 #: _guides/ansible.adoc

--- a/l10n/po/ja_JP/_guides/cli-tooling.adoc.po
+++ b/l10n/po/ja_JP/_guides/cli-tooling.adoc.po
@@ -477,10 +477,10 @@ msgid "`--origins` Display concise information along with the Quarkus platform r
 msgstr "`--origins` conciseフォーマットと共に、エクステンションのQuarkusプラットフォームリリースオリジンを表示します。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "`--support-scope` Display support scope associated with each extension (if any) for an offering configured in the registry client configuration."
-msgstr "`--support-scope` レジストリのクライアント構成で構成されたオファリングの各拡張（もしあれば）に関連するサポートスコープを表示します。"
+msgstr "`--support-scope` レジストリークライアント設定で設定されたオファリングに対して、各エクステンション (もしあれば) に関連付けられたサポートスコープを表示します。"
 
 #. type: Plain text
 #: _guides/cli-tooling.adoc
@@ -530,28 +530,28 @@ msgid "You can narrow or filter the list using search (`--search` or `-s`)."
 msgstr "You can narrow or filter the list using search (`--search` or `-s`)."
 
 #. type: Title ===
+#. mt: gemini
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "Listing extensions for a specific offering"
-msgstr "特定のオファーのためのリスティング拡張機能"
+msgstr "特定のオファリングのエクステンションのリスト表示"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "This option was introduced in 3.26.0 and will be evolving in the upcoming releases."
-msgstr "このオプションは3.26.0で導入され、今後のリリースで進化していく予定です。"
+msgstr "このオプションは 3.26.0 で導入され、今後のリリースで進化していく予定です。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "As described in link:{quarkus-home-url}/guides/extension-registry-user#limiting-extension-catalog-to-an-offering[the registry client documentation], an extension catalog could be limited to a specific extension offering delivered and supported by a dedicated team or an organization."
-msgstr "link:{quarkus-home-url}/guides/extension-registry-user#limiting-extension-catalog-to-an-offering[レジストリクライアントのドキュメントに] 記載されているように、拡張機能カタログは、専門のチームまたは組織によって提供され、サポートされる特定の拡張機能に限定することができます。"
+msgstr "link:{quarkus-home-url}/guides/extension-registry-user#limiting-extension-catalog-to-an-offering[レジストリークライアントのドキュメント]に記載されているように、エクステンションカタログは、専任のチームまたは組織によって提供およびサポートされる特定のエクステンションオファリングに限定できます。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/cli-tooling.adoc
-#, fuzzy
 msgid "When an offering is configured for a registry in `.quarkus/config.yaml`, `ext list --support-scope` can be used to display support scope associated with extensions from the selected offering. For example,"
-msgstr "オファリングが `.quarkus/config.yaml` のレジストリ用に構成されている場合、 `ext list --support-scope` を使用して、選択されたオファリングからのエクステンションに関連するサポートスコープを表示することができます。例えば"
+msgstr "`.quarkus/config.yaml` でレジストリーのオファリングが設定されている場合、`ext list --support-scope` を使用して、選択されたオファリングのエクステンションに関連付けられたサポートスコープを表示できます。例:"
 
 #. type: Title ===
 #: _guides/cli-tooling.adoc

--- a/l10n/po/ja_JP/_guides/getting-started-dev-services.adoc.po
+++ b/l10n/po/ja_JP/_guides/getting-started-dev-services.adoc.po
@@ -418,8 +418,8 @@ msgid "Initialising services"
 msgstr "サービスの初期化"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/getting-started-dev-services.adoc
-#, fuzzy
 msgid ""
 "If you play with your code some more, you may notice that sometimes, after making an application change, http://localhost:8080/hello/names doesn't list any names.\n"
 "What's going on? By default, in dev mode, with a Dev Services database,\n"
@@ -427,7 +427,7 @@ msgid ""
 "See the xref:hibernate-orm.adoc#quarkus-hibernate-orm_quarkus-hibernate-orm-schema-management-strategy[Hibernate configuration reference] for more details.\n"
 "If a code change triggers an application restart, the database tables\n"
 "will be dropped (deleted) and then re-created."
-msgstr "もう少しコードをいじってみると、アプリケーションを変更した後、 link:http://localhost:8080/hello/names[http://localhost:8080] /hello/names、名前が一覧表示されないことがあることに気づくかもしれません。何が起こっているのでしょうか？デフォルトでは、開発モードでDev Servicesデータベースを使用する場合、QuarkusはHibernate ORMデータベーススキーマ管理ストラテジーを `drop-and-create` 。詳細については、 xref:hibernate-orm.adoc#quarkus-hibernate-orm_quarkus-hibernate-orm-schema-management-strategy[Hibernateの設定リファレンスを] 参照してください。コード変更がアプリケーションの再起動をトリガーする場合、データベーステーブルはドロップ（削除）され、その後再作成されます。"
+msgstr "コードをもう少し試してみると、アプリケーションを変更した後、 http://localhost:8080/hello/names に名前が表示されないことがあることに気づくかもしれません。何が起こっているのでしょうか? デフォルトでは、開発モードで Dev Services データベースを使用している場合、Quarkus は、Hibernate ORM のデータベーススキーマ管理戦略を `drop-and-create` に設定します。詳細は、xref:hibernate-orm.adoc#quarkus-hibernate-orm_quarkus-hibernate-orm-schema-management-strategy[Hibernate 設定リファレンス] を参照してください。コードの変更によりアプリケーションの再起動がトリガーされると、データベーステーブルはドロップ (削除) され、その後再作成されます。"
 
 #. type: Plain text
 #: _guides/getting-started-dev-services.adoc

--- a/l10n/po/ja_JP/_guides/grpc-generation-reference.adoc.po
+++ b/l10n/po/ja_JP/_guides/grpc-generation-reference.adoc.po
@@ -41,12 +41,12 @@ msgid "To enable gRPC code generation, add the following dependency to your proj
 msgstr "gRPC コード生成を有効化するには、プロジェクトに以下の依存関係を追加します。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/grpc-generation-reference.adoc
-#, fuzzy
 msgid ""
 "The `quarkus:generate-code` goal is executed by default during the Quarkus Maven plugin default lifecycle when using the `quarkus` packaging,\n"
 "and will handle the code generation."
-msgstr "`quarkus` パッケージングを使用している場合、Quarkus Maven プラグインのデフォルトのライフサイクル中に `quarkus:generate-code` ゴールがデフォルトで実行され、コード生成が処理されます。"
+msgstr "`quarkus:generate-code` ゴールは、`quarkus` パッケージングを使用する際に、Quarkus Maven プラグインのデフォルトライフサイクル中にデフォルトで実行され、コード生成を処理します。"
 
 #. type: Title ==
 #: _guides/grpc-generation-reference.adoc
@@ -573,10 +573,10 @@ msgid "Because of the packaging of `protoc` and the plugin (using classifier), i
 msgstr "`protoc` とプラグインのパッケージング (分類子を使用) により、不要なプラットフォームを個別に除外することはできません。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/grpc-generation-reference.adoc
-#, fuzzy
 msgid "When using https://en.wikipedia.org/wiki/AArch64[AArch64] on macOS be aware of this https://github.com/grpc/grpc-java/issues/11844[issue]: meaning that the macOS https://en.wikipedia.org/wiki/X86[x86_64] protoc and macOS aarch_64 protoc are the `same` - both are macOS x86_64. So you need to enable https://en.wikipedia.org/wiki/Rosetta_(software)[Rosetta] (`softwareupdate --install-rosetta`) on your ARM based macOS if you want to generate protobuf classes."
-msgstr "macOSで link:https://en.wikipedia.org/wiki/AArch64[AArch64を] 使用する場合は、この link:https://github.com/grpc/grpc-java/issues/11844[問題に] 注意してください：つまり、macOS link:https://en.wikipedia.org/wiki/X86[x86_64] プロトタイプとmacOS aarch_64プロトタイプは `same` - どちらもmacOS x86_64です。つまり、protobufクラスを生成したい場合は、ARMベースのmacOSで link:https://en.wikipedia.org/wiki/Rosetta_(software)[Rosetta] ( `softwareupdate --install-rosetta` ) を有効にする必要があります。"
+msgstr "macOS で https://en.wikipedia.org/wiki/AArch64[AArch64] を使用する場合、この https://github.com/grpc/grpc-java/issues/11844[問題] に注意してください。つまり、macOS の https://en.wikipedia.org/wiki/X86[x86_64] protoc と macOS の aarch_64 protoc は `同じ` であり、どちらも macOS x86_64 です。したがって、protobuf クラスを生成したい場合は、ARM ベースの macOS で https://en.wikipedia.org/wiki/Rosetta_(software)[Rosetta] (`softwareupdate --install-rosetta`) を有効にする必要があります。"
 
 #. type: Plain text
 #: _guides/grpc-generation-reference.adoc

--- a/l10n/po/ja_JP/_guides/kafka-dev-services.adoc.po
+++ b/l10n/po/ja_JP/_guides/kafka-dev-services.adoc.po
@@ -178,19 +178,19 @@ msgid "Configuring Kafka topics"
 msgstr "Kafkaトピックの設定"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/kafka-dev-services.adoc
-#, fuzzy
 msgid ""
 "You can configure the Dev Services for Kafka to create topics once the broker is started.\n"
 "Topics are created with given number of partitions and 1 replica.\n"
 "The syntax is the following:"
-msgstr "Dev Services for Kafkaは、ブローカーが起動するとトピックを作成するように設定できます。トピックは、指定された数のパーティションと1つのレプリカで作成されます。構文は次のとおりです："
+msgstr "Kafka向けDev Services を設定して、ブローカーの起動時にトピックを作成できます。トピックは、指定されたパーティション数と1つのレプリカで作成されます。構文は以下のとおりです。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/kafka-dev-services.adoc
-#, fuzzy
 msgid "The following example creates a topic named `test` with three partitions, and a second topic named `messages` with two partitions."
-msgstr "次の例では、3 つのパーティションを持つ `test` という名前のトピックと、2 つのパーティションを持つ `messages` という名前の 2 番目のトピックを作成します。"
+msgstr "次の例では、3つのパーティションを持つ `test` という名前のトピックと、2つのパーティションを持つ `messages` という名前の2番目のトピックを作成します。"
 
 #. type: Plain text
 #: _guides/kafka-dev-services.adoc
@@ -230,18 +230,18 @@ msgid "Compose"
 msgstr "Compose"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/kafka-dev-services.adoc
-#, fuzzy
 msgid ""
 "The Kafka Dev Services supports xref:compose-dev-services.adoc[Compose Dev Services].\n"
 "It relies on a `compose-devservices.yml`, such as:"
-msgstr "Kafka Dev Services は xref:compose-dev-services.adoc[Compose Dev Services を] サポートしています。これは `compose-devservices.yml` に依存しています："
+msgstr "Kafka Dev Services は xref:compose-dev-services.adoc[Compose Dev Services] をサポートしています。これは、以下のような `compose-devservices.yml` に依存します。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/kafka-dev-services.adoc
-#, fuzzy
 msgid "For the broker to advertise its externally accessible address to clients, it requires an additional file `kafka.sh` as described in xref:compose-dev-services.adoc#exposing-port-mappings-to-running-containers[Exposing port mappings to running containers]."
-msgstr "ブローカーがクライアントに外部からアクセス可能なアドレスをアドバタイズするには、 xref:compose-dev-services.adoc#exposing-port-mappings-to-running-containers[実行中のコンテナにポートマッピングを公開するで] 説明したように、追加のファイル `kafka.sh` が必要です。"
+msgstr "ブローカーがその外部からアクセス可能なアドレスをクライアントにアドバタイズするには、xref:compose-dev-services.adoc#exposing-port-mappings-to-running-containers[実行中のコンテナーへのポートマッピングの公開] に記述されているように、追加のファイル `kafka.sh` が必要です。"
 
 #. type: Title ==
 #: _guides/kafka-dev-services.adoc

--- a/l10n/po/ja_JP/_guides/kafka-streams.adoc.po
+++ b/l10n/po/ja_JP/_guides/kafka-streams.adoc.po
@@ -400,10 +400,10 @@ msgid ""
 msgstr "Quarkusがデフォルトで作成した `Dockerfile` は、Kafka Streamsパイプラインを実行するために、 `aggregator` アプリケーションに1つの調整が必要です。そのためには、 `aggregator/src/main/docker/Dockerfile.jvm` ファイルを編集して、 `FROM fabric8/java-alpine-openjdk8-jre` の行を `FROM fabric8/java-centos-openjdk8-jdk` に置き換えます。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "Next create a Docker Compose file (`docker-compose.yaml`) for spinning up the two applications as well as Apache Kafka like so:"
-msgstr "次に、2つのアプリケーションとApache KafkaをスピンアップするためのDocker Composeファイル( `docker-compose.yaml` )を作成します："
+msgstr "次に、2つのアプリケーションとApache Kafkaを起動するためのDocker Compose ファイル ( `docker-compose.yaml` ) を次のように作成します。"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
@@ -780,15 +780,15 @@ msgid "Going Further"
 msgstr "さらに詳しく"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "This guide has shown how you can build stream processing applications using Quarkus and the Kafka Streams APIs,\n"
 "both in JVM and native modes.\n"
 "For running your KStreams application in production, you could also add health checks and metrics for the data pipeline.\n"
 "Refer to the Quarkus guides on xref:telemetry-micrometer.adoc[Micrometer],\n"
 "and xref:smallrye-health.adoc[SmallRye Health] to learn more."
-msgstr "このガイドでは、QuarkusとKafka Streams APIを使用して、JVMモードとネイティブモードの両方でストリーム処理アプリケーションを構築する方法を紹介しました。本番環境でKStreamsアプリケーションを実行するには、データパイプラインのヘルスチェックとメトリクスを追加することもできます。詳細については、Quarkusの xref:telemetry-micrometer.adoc[Micrometerと] xref:smallrye-health.adoc[SmallRye Healthの] ガイドを参照してください。"
+msgstr "このガイドでは、Quarkus と Kafka Streams API を使用して、JVM モードとネイティブモードの両方でストリーム処理アプリケーションを構築する方法を示しました。KStreams アプリケーションを本番環境で実行するために、データパイプラインのヘルスチェックとメトリクスを追加することもできます。詳細については、xref:telemetry-micrometer.adoc[Micrometer] および xref:smallrye-health.adoc[SmallRye Health] に関する Quarkus ガイドを参照してください。"
 
 #. type: Title =
 #: _guides/kafka-streams.adoc

--- a/l10n/po/ja_JP/_guides/liquibase-mongodb.adoc.po
+++ b/l10n/po/ja_JP/_guides/liquibase-mongodb.adoc.po
@@ -102,13 +102,13 @@ msgid "build.gradle"
 msgstr "build.gradle"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/liquibase-mongodb.adoc
-#, fuzzy
 msgid ""
 "The Liquibase MongoDB extension support relies on the Quarkus MongoDB client config.\n"
 "You need to add the MongoDB config to the `{config-file}` file\n"
 "in order to allow Liquibase to manage the schema."
-msgstr "Liquibase MongoDB 拡張機能のサポートは、Quarkus MongoDB クライアント設定に依存しています。Liquibase がスキーマを管理できるようにするために、 `{config-file}` ファイルに MongoDB 設定を追加する必要があります。"
+msgstr "Liquibase MongoDB エクステンションのサポートは、Quarkus MongoDB クライアント設定に依存しています。Liquibase がスキーマを管理できるようにするには、MongoDB 設定を `{config-file}` ファイルに追加する必要があります。"
 
 #. type: Plain text
 #: _guides/liquibase-mongodb.adoc
@@ -138,24 +138,24 @@ msgid "Now you can start your application and Quarkus will run the Liquibase's u
 msgstr "これで、アプリケーションを起動できるようになり、Quarkusは設定に従ってLiquibaseのアップデートメソッドを実行します。"
 
 #. type: Title =
+#. mt: gemini
 #: _guides/liquibase-mongodb.adoc
-#, fuzzy
 msgid "Multiple Clients"
 msgstr "複数のクライアント"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/liquibase-mongodb.adoc
-#, fuzzy
 msgid ""
 "Liquibase MongoDB can be configured to support multiple clients.\n"
 "The properties are prefixed exactly the same way as named MongoDB clients. For example:"
-msgstr "Liquibase MongoDB は複数のクライアントをサポートするように設定できます。プロパティのプレフィックスは MongoDB クライアントとまったく同じです。たとえば"
+msgstr "Liquibase MongoDB は、複数のクライアントをサポートするように設定できます。プロパティーには、名前付き MongoDB クライアントと全く同じ方法でプレフィックスが付与されます。例:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/liquibase-mongodb.adoc
-#, fuzzy
 msgid "The property `quarkus.liquibase-mongodb.[MongoDB client name].change-log` is the minimal configuration required for the extension to detect a new client setup."
-msgstr "プロパティ `quarkus.liquibase-mongodb.[MongoDB client name].change-log` は、拡張機能が新しいクライアント設定を検出するために必要な最小構成です。"
+msgstr "プロパティー `quarkus.liquibase-mongodb.[MongoDB client name].change-log` は、エクステンションが新しいクライアント設定を検出するために必要な最小限の設定です。"
 
 #. type: Title =
 #: _guides/liquibase-mongodb.adoc
@@ -181,10 +181,10 @@ msgid "Inject the LiquibaseFactory object"
 msgstr "LiquibaseFactory オブジェクトのインジェクション"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/liquibase-mongodb.adoc
-#, fuzzy
 msgid "Inject Liquibase MongoDB for named clients using the Quarkus `LiquibaseMongodbClient` qualifier"
-msgstr "Quarkus `LiquibaseMongodbClient` を使って、指定したクライアントに Liquibase MongoDB をインジェクトします。"
+msgstr "Quarkus の `LiquibaseMongodbClient` 修飾子を使用して、名前付きクライアントに Liquibase MongoDB を注入します"
 
 #. type: Plain text
 #: _guides/liquibase-mongodb.adoc
@@ -197,10 +197,10 @@ msgid "List of applied or not applied liquibase ChangeSets"
 msgstr "適用された、または適用されていないliquibaseのChangeSetsのリスト"
 
 #. type: Title =
+#. mt: gemini
 #: _guides/liquibase-mongodb.adoc
-#, fuzzy
 msgid "Liquibase MongoDB on Kubernetes"
-msgstr "Kubernetes上のLiquibase MongoDB"
+msgstr "Kubernetes 上の Liquibase MongoDB"
 
 #. type: Plain text
 #: _guides/liquibase-mongodb.adoc

--- a/l10n/po/ja_JP/_guides/qute.adoc.po
+++ b/l10n/po/ja_JP/_guides/qute.adoc.po
@@ -137,16 +137,16 @@ msgid "Hello Qute and REST"
 msgstr "Hello Qute と REST"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/qute.adoc
-#, fuzzy
 msgid "For finer control, you can combine Qute Web with Quarkus REST (formerly RESTEasy Reactive) or the legacy RESTEasy Classic-based extension to control how your template will be served"
-msgstr "Qute WebをQuarkus REST（旧RESTEasy Reactive）または従来のRESTEasy Classicベースの拡張機能と組み合わせることで、テンプレートの配信方法をより細かく制御できます。"
+msgstr "よりきめ細かく制御するには、Qute Web を Quarkus REST (旧 RESTEasy Reactive) または従来の RESTEasy Classic ベースの エクステンション と組み合わせて、テンプレートがどのように提供されるかを制御できます。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/qute.adoc
-#, fuzzy
 msgid "Using the `quarkus-rest-qute` extension:"
-msgstr "`quarkus-rest-qute` ："
+msgstr "`quarkus-rest-qute` エクステンション の使用:"
 
 #. type: Plain text
 #: _guides/qute.adoc
@@ -186,10 +186,10 @@ msgid "`Template.data()` returns a new template instance that can be customized 
 msgstr "`Template.data()` は、実際のレンダリングがトリガーされる前にカスタマイズできる新しいテンプレートインスタンスを返します。この場合、名前の値をキー `name` の下に置きます。データマップはレンダリング中にアクセス可能です。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/qute.adoc
-#, fuzzy
 msgid "Note that we don't trigger the rendering - this is done automatically by a special `ContainerResponseFilter` implementation provided by `quarkus-rest-qute`."
-msgstr "私たちはレンダリングをトリガーしていないことに注意してください - これは `quarkus-rest-qute` によって提供される特別な `ContainerResponseFilter` 実装によって自動的に行われます。"
+msgstr "レンダリングはトリガーしないことに注意してください。これは、`quarkus-rest-qute` が提供する特別な `ContainerResponseFilter` 実装によって自動的に行われます。"
 
 #. type: Plain text
 #: _guides/qute.adoc
@@ -259,10 +259,10 @@ msgid "This declares a template with path `templates/HelloResource/hello`."
 msgstr "これは、パス `templates/HelloResource/hello.txt` でテンプレートを宣言します。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/qute.adoc
-#, fuzzy
 msgid "`Templates.hello()` returns a new template instance that is returned from the resource method. Note that we don't trigger the rendering - this is done automatically by a special `ContainerResponseFilter` implementation provided by `quarkus-rest-qute`."
-msgstr "`Templates.hello()` はリソースメソッドから返された新しいテンプレートインスタンスを返します。私たちはレンダリングをトリガーしないことに注意してください - これは が提供する特別な 実装によって自動的に行われます。 `quarkus-rest-qute` `ContainerResponseFilter` "
+msgstr "`Templates.hello()` は、リソースメソッドから返される新しいテンプレートインスタンスを返します。レンダリングはトリガーしないことに注意してください。これは、`quarkus-rest-qute` が提供する特別な `ContainerResponseFilter` 実装によって自動的に行われます。"
 
 #. type: Plain text
 #: _guides/qute.adoc

--- a/l10n/po/ja_JP/_guides/smallrye-fault-tolerance.adoc.po
+++ b/l10n/po/ja_JP/_guides/smallrye-fault-tolerance.adoc.po
@@ -538,12 +538,12 @@ msgid "Additional resources"
 msgstr "関連情報"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-fault-tolerance.adoc
-#, fuzzy
 msgid ""
 "SmallRye Fault Tolerance has more features than shown here.\n"
 "Please check the link:https://smallrye.io/docs/smallrye-fault-tolerance/6.10.0/index.html[SmallRye Fault Tolerance documentation] to learn about them."
-msgstr "SmallRye Fault Toleranceには、ここに示した以外にも多くの機能があります。これらの機能については、 link:https://smallrye.io/docs/smallrye-fault-tolerance/6.10.0/index.html[SmallRye Fault Toleranceのドキュメントを] 参照してください。"
+msgstr "SmallRye Fault Toleranceには、ここで紹介した以外にも多くの機能があります。これらの機能については、 link:https://smallrye.io/docs/smallrye-fault-tolerance/6.10.0/index.html[SmallRye Fault Toleranceのドキュメント] を参照してください。"
 
 #. type: Plain text
 #: _guides/smallrye-fault-tolerance.adoc
@@ -593,12 +593,12 @@ msgid ""
 msgstr "このモードは、非互換性は非常に小さいものの、MicroProfile Fault Tolerance仕様と互換性がありません。 完全な互換性を回復するには、このコンフィギュレーションプロパティを追加してください。 :"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-fault-tolerance.adoc
-#, fuzzy
 msgid ""
 "The link:https://smallrye.io/docs/smallrye-fault-tolerance/6.10.0/reference/programmatic-api.html[programmatic API] is present and integrated with the declarative, annotation-based API.\n"
 "You can use the `Guard`, `TypedGuard` and `@ApplyGuard` APIs out of the box."
-msgstr "link:https://smallrye.io/docs/smallrye-fault-tolerance/6.10.0/reference/programmatic-api.html[プログラムAPIは] 、宣言的なアノテーション・ベースのAPIと統合されています。 `Guard` 、 `TypedGuard` 、 `@ApplyGuard` のAPIをすぐに使うことができます。"
+msgstr "link:https://smallrye.io/docs/smallrye-fault-tolerance/6.10.0/reference/programmatic-api.html[プログラムAPI] が存在し、宣言的なアノテーションベースのAPIと統合されています。 `Guard`、 `TypedGuard`、および `@ApplyGuard` のAPIをすぐに使用できます。"
 
 #. type: Plain text
 #: _guides/smallrye-fault-tolerance.adoc
@@ -606,14 +606,14 @@ msgid "Support for Kotlin is present (assuming you use the Quarkus extension for
 msgstr "Kotlinのサポートがあるため（Kotlin用のQuarkusエクステンションを使用することが前提）、フォールトトレランスのアノテーションで `suspend` 関数を保護することができます。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/smallrye-fault-tolerance.adoc
-#, fuzzy
 msgid ""
 "Metrics are automatically discovered and integrated.\n"
 "If your application uses the Quarkus extension for Micrometer, SmallRye Fault Tolerance will emit metrics to Micrometer.\n"
 "Otherwise, SmallRye Fault Tolerance will emit metrics to OpenTelemetry Metrics if OpenTelemetry Metrics is available.\n"
 "If no Quarkus metrics extension is present, SmallRye Fault Tolerance metrics will be disabled."
-msgstr "メトリクスは自動的に検出され、統合されます。アプリケーションがMicrometer用のQuarkus拡張機能を使用している場合、SmallRye Fault ToleranceはMicrometerにメトリクスを送信します。それ以外の場合、OpenTelemetry Metricsが利用可能であれば、SmallRye Fault ToleranceはOpenTelemetry Metricsにメトリクスを送信します。Quarkus メトリクス拡張機能がない場合、SmallRye Fault Tolerance メトリクスは無効になります。"
+msgstr "メトリクスは自動的に検出され、統合されます。アプリケーションが Micrometer 用の Quarkus エクステンションを使用している場合、SmallRye Fault Tolerance は Micrometer にメトリクスを送信します。そうでない場合、OpenTelemetry Metrics が利用可能であれば、SmallRye Fault Tolerance は OpenTelemetry Metrics にメトリクスを送信します。Quarkus のメトリクスエクステンションが存在しない場合、SmallRye Fault Tolerance のメトリクスは無効になります。"
 
 #. type: Title =
 #: _guides/smallrye-fault-tolerance.adoc


### PR DESCRIPTION
## Summary

Retranslate fuzzy messages in 6 guides from the bottom of the fuzzy message list.

## Files retranslated

- ansible.adoc.po
- smallrye-fault-tolerance.adoc.po
- cli-tooling.adoc.po
- kafka-dev-services.adoc.po
- liquibase-mongodb.adoc.po
- qute.adoc.po

## Implementation

Each file was processed through the standard retranslation workflow:
1. `tsujiw po purge` (fuzzy messages only)
2. `tsujiw po machine-translate`
3. `tsujiw po unfuzzy`