### PR TITLE
Retranslate fuzzy messages in 10 guides (batch 3)

### DIFF
--- a/l10n/po/ja_JP/_guides/container-image.adoc.po
+++ b/l10n/po/ja_JP/_guides/container-image.adoc.po
@@ -122,10 +122,10 @@ msgid "The exact configuration is:"
 msgstr "具体的な構成例:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/container-image.adoc
-#, fuzzy
 msgid "Other base images might provide launch scripts that enable debugging when an environment variable is set, in which case you would set that environment variable when launching the container."
-msgstr "他のベースイメージでは、環境変数が設定されている場合にデバッグを有効にする起動スクリプトが提供されているかもしれません。"
+msgstr "他のベースイメージでは、環境変数の設定によってデバッグが可能になる起動スクリプトが提供されている場合があります。その場合は、コンテナーの起動時にその環境変数を設定します。"
 
 #. type: Title ===
 #: _guides/container-image.adoc
@@ -195,12 +195,12 @@ msgid "AppCDS"
 msgstr "AppCDS"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/container-image.adoc
-#, fuzzy
 msgid ""
 "Quarkus supports generating and including AOT caches (including link:https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html#application-class-data-sharing[Application Class Data Sharing] archives) when generating container images.\n"
 "See the xref:aot.adoc[AOT Caching documentation] for more details."
-msgstr "Quarkusでは、コンテナイメージの生成時に、AOTキャッシュ（ link:https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html#application-class-data-sharing[アプリケーションクラスデータ共有] アーカイブを含む）の生成と追加がサポートされています。詳細については、 xref:aot.adoc[AOTキャッシュのドキュメントを] 参照してください。"
+msgstr "Quarkus は、コンテナーイメージを生成する際に、AOT キャッシュ (link:https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html#application-class-data-sharing[Application Class Data Sharing] アーカイブを含む) の生成と組み込みをサポートしています。詳細については、xref:aot.adoc[AOT キャッシングのドキュメント] を参照してください。"
 
 #. type: Title ==
 #: _guides/container-image.adoc
@@ -270,12 +270,12 @@ msgid "OpenShift"
 msgstr "OpenShift"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/container-image.adoc
-#, fuzzy
 msgid ""
 "The extension `quarkus-container-image-openshift` is using OpenShift binary builds in order to perform container builds inside the OpenShift cluster.\n"
 "The idea behind the binary build is that you just upload the artifact and its dependencies to the cluster and during the build they will be merged to a builder image (defaults to `ubi9/openjdk-17` or `ubi9/openjdk-21`)."
-msgstr "`quarkus-container-image-openshift` という拡張は、OpenShift クラスタ内でコンテナのビルドを実行するために OpenShift のバイナリビルドを使用しています。バイナリビルドの背後にある考え方は、アーティファクトとその依存関係をクラスタにアップロードするだけで、ビルド中にそれらがビルダーイメージ（デフォルトは `ubi9/openjdk-17` または `ubi9/openjdk-21` ）にマージされるということです。"
+msgstr "エクステンション `quarkus-container-image-openshift` は、OpenShift クラスター内でコンテナービルドを実行するために、OpenShift バイナリービルドを使用しています。バイナリービルドの背景にある考え方は、アーティファクトとその依存関係をクラスターにアップロードするだけで、ビルド中にそれらがビルダーイメージ (デフォルトは `ubi9/openjdk-17` または `ubi9/openjdk-21`) にマージされるというものです。"
 
 #. type: Plain text
 #: _guides/container-image.adoc
@@ -512,16 +512,16 @@ msgid "<span class=\"icon\"><i class=\"fa fa-lock\" title=\"Fixed at build time\
 msgstr "<span class=\"icon\"><i class=\"fa fa-lock\" title=\"ビルド時に固定\"></i></span> ビルド時に固定される設定プロパティ - 他のすべての設定プロパティは、実行時にオーバーライド可能 <input type=\"search\" id=\"config-search-4\" placeholder=\"FILTER CONFIGURATION\" disabled>"
 
 #. type: Title ==
+#. mt: gemini
 #: _guides/container-image.adoc
-#, fuzzy
 msgid "Buildpack Options"
-msgstr "ビルドパックオプション"
+msgstr "Buildpack オプション"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/container-image.adoc
-#, fuzzy
 msgid "In addition to the generic container image options, the `container-image-buildpack` also provides the following options:"
-msgstr "一般的なコンテナ・イメージ・オプションに加えて、 `container-image-buildpack` には以下のオプションもあります："
+msgstr "一般的なコンテナーイメージのオプションに加えて、`container-image-buildpack` は以下のオプションも提供します。"
 
 #. type: Plain text
 #: _guides/container-image.adoc

--- a/l10n/po/ja_JP/_guides/deploying-to-openshift-s2i-howto.adoc.po
+++ b/l10n/po/ja_JP/_guides/deploying-to-openshift-s2i-howto.adoc.po
@@ -19,10 +19,10 @@ msgid ""
 msgstr "{project-name} のアプリケーションを {openshift-long} にデプロイするには、Source-to-Image (S2I) メソッドを使用します。S2Iでは、Gitリポジトリを通して、あるいはビルド時にソースコードをアップロードして、ビルドコンテナにソースコードを提供する必要があります。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/deploying-to-openshift-s2i-howto.adoc
-#, fuzzy
 msgid "You can deploy {project-name} applications to {openshift} with Java {jdk-version-all} versions."
-msgstr "jdk-version-all} バージョンの {openshift} に {project-name} アプリケーションをデプロイできます。"
+msgstr "{project-name} アプリケーションを Java {jdk-version-all} で {openshift} にデプロイできます。"
 
 #. type: Title =
 #: _guides/deploying-to-openshift-s2i-howto.adoc
@@ -30,10 +30,10 @@ msgid "Prerequisites"
 msgstr "前提条件"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/deploying-to-openshift-s2i-howto.adoc
-#, fuzzy
 msgid "You have a Quarkus application built with Java {jdk-version-all}."
-msgstr "Java{jdk-version-all}で構築されたQuarkusアプリケーションがあります。"
+msgstr "Java {jdk-version-all} で構築された Quarkus アプリケーションがあります。"
 
 #. type: Plain text
 #: _guides/deploying-to-openshift-s2i-howto.adoc
@@ -56,22 +56,22 @@ msgid "Procedure"
 msgstr "手順"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/deploying-to-openshift-s2i-howto.adoc
-#, fuzzy
 msgid "Open the `pom.xml` file, and set the Java version."
-msgstr "`pom.xml` ファイルを開き、Java のバージョンを設定します。"
+msgstr "`pom.xml` ファイルを開き、Java バージョンを設定します。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/deploying-to-openshift-s2i-howto.adoc
-#, fuzzy
 msgid "where ${java.version} is {jdk-version-all}."
-msgstr "ここで${java.version}は{jdk-version-all}です。"
+msgstr "ここで ${java.version} は {jdk-version-all} です。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/deploying-to-openshift-s2i-howto.adoc
-#, fuzzy
 msgid "Package your application, by entering the following command:"
-msgstr "以下のコマンドを入力して、アプリケーションをパッケージ化します："
+msgstr "以下のコマンドを入力して、アプリケーションをパッケージ化します。"
 
 #. type: Plain text
 #: _guides/deploying-to-openshift-s2i-howto.adoc
@@ -89,28 +89,28 @@ msgid "Commit and push your changes to the remote Git repository."
 msgstr "変更をコミットして、リモートの Git リポジトリにプッシュします。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/deploying-to-openshift-s2i-howto.adoc
-#, fuzzy
 msgid "Import the supported {openshift} image."
 msgstr "サポートされている {openshift} イメージをインポートします。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/deploying-to-openshift-s2i-howto.adoc
-#, fuzzy
 msgid "Java {jdk-version-earliest}:"
-msgstr "Java {jdk-version-earliest}："
+msgstr "Java {jdk-version-earliest}:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/deploying-to-openshift-s2i-howto.adoc
-#, fuzzy
 msgid "Java {jdk-version-other}:"
-msgstr "Java {jdk-version-other}："
+msgstr "Java {jdk-version-other}:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/deploying-to-openshift-s2i-howto.adoc
-#, fuzzy
 msgid "Java {jdk-version-latest}:"
-msgstr "Java {jdk-version-latest}："
+msgstr "Java {jdk-version-latest}:"
 
 #. type: Plain text
 #: _guides/deploying-to-openshift-s2i-howto.adoc
@@ -128,26 +128,26 @@ msgid "For more information, see the link:https://docs.openshift.com/container-p
 msgstr "詳細は、 link:https://docs.openshift.com/container-platform/[Red Hat Openshift Container Platform] のドキュメントを参照してください。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/deploying-to-openshift-s2i-howto.adoc
-#, fuzzy
 msgid ""
 "If you are deploying on IBM Z infrastructure, enter `oc import-image {name-image-ubi9-open-jdk-21-short} --from=registry.redhat.io/{name-image-ubi9-open-jdk-21-short} --confirm` instead.\n"
 "For information about this image, see link:https://catalog.redhat.com/en/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f[OpenJDK 21 runtime image on UBI9]."
-msgstr "IBM Z インフラストラクチャにデプロイする場合は、代わりに `oc import-image {name-image-ubi9-open-jdk-21-short} --from=registry.redhat.io/{name-image-ubi9-open-jdk-21-short} --confirm` と入力してください。このイメージについては、 link:https://catalog.redhat.com/en/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f[UBI9上のOpenJDK 21ランタイム・イメージを] 参照してください。"
+msgstr "IBM Z インフラストラクチャにデプロイする場合は、代わりに `oc import-image {name-image-ubi9-open-jdk-21-short} --from=registry.redhat.io/{name-image-ubi9-open-jdk-21-short} --confirm` を入力します。このイメージに関する情報は、 link:https://catalog.redhat.com/en/software/containers/ubi9/openjdk-21-runtime/6501ce769a0d86945c422d5f[UBI9 上の OpenJDK 21 ランタイムイメージ] を参照してください。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/deploying-to-openshift-s2i-howto.adoc
-#, fuzzy
 msgid "Build the project, create the application, and deploy the {openshift} service."
-msgstr "プロジェクトをビルドし、アプリケーションを作成し、{openshift}サービスをデプロイします。"
+msgstr "プロジェクトをビルドし、アプリケーションを作成し、{openshift} サービスをデプロイします。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/deploying-to-openshift-s2i-howto.adoc
-#, fuzzy
 msgid ""
 "Replace `<git_path>` with the path of the Git repository that hosts your Quarkus project.\n"
 "For example, for Java {jdk-version-other}: `oc new-app registry.access.redhat.com/ubi9/openjdk-21~https://github.com/johndoe/code-with-quarkus.git --name=code-with-quarkus`."
-msgstr "`<git_path>` は、QuarkusプロジェクトをホストしているGitリポジトリのパスに置き換えてください。例えば、Java {jdk-version-other}の場合： `oc new-app registry.access.redhat.com/ubi9/openjdk-21~https://github.com/johndoe/code-with-quarkus.git --name=code-with-quarkus` ."
+msgstr "`<git_path>` を、Quarkus プロジェクトをホストする Git リポジトリーのパスに置き換えます。例えば、Java {jdk-version-other} の場合: `oc new-app registry.access.redhat.com/ubi9/openjdk-21~https://github.com/johndoe/code-with-quarkus.git --name=code-with-quarkus`。"
 
 #. type: Plain text
 #: _guides/deploying-to-openshift-s2i-howto.adoc

--- a/l10n/po/ja_JP/_guides/grpc-service-implementation.adoc.po
+++ b/l10n/po/ja_JP/_guides/grpc-service-implementation.adoc.po
@@ -290,22 +290,22 @@ msgid "To use TLS with mutual authentication, use the following configuration:"
 msgstr "相互認証付きのTLSを使用するには、以下の設定を使用します。"
 
 #. type: Title ==
+#. mt: gemini
 #: _guides/grpc-service-implementation.adoc
-#, fuzzy
 msgid "Custom server building"
-msgstr "カスタムサーバー構築"
+msgstr "カスタムサーバーの構築"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/grpc-service-implementation.adoc
-#, fuzzy
 msgid "When Quarkus builds a gRPC server instance, users can apply their own Server(Builder) customizers. The customizers are applied by `priority`, the higher the number the later customizer is applied. The customizers are applied before Quarkus applies user's server configuration; e.g. ideal for some initial defaults."
-msgstr "QuarkusでgRPCサーバーインスタンスを構築する際、ユーザーは独自のServer(Builder)カスタマイザを適用できます。カスタマイザは、 `priority` 、数字が大きいほど後から適用されます。カスタマイザは、Quarkusがユーザーのサーバー構成を適用する前に適用されます。"
+msgstr "Quarkus が gRPC サーバーインスタンスを構築する際、ユーザーは独自の Server(Builder) カスタマイザーを適用できます。カスタマイザーは `priority` によって適用され、数字が大きいほど後に適用されます。カスタマイザーは、Quarkus がユーザーのサーバー設定を適用する前に適用されます。たとえば、いくつかの初期デフォルト設定に最適です。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/grpc-service-implementation.adoc
-#, fuzzy
 msgid "There are two `customize` methods, the first one uses gRPC's `ServerBuilder` as a parameter - to be used with Quarkus' legacy gRPC support, where the other uses `GrpcServerOptions` - to be used with the new Vert.x gRPC support. User should implement the right `customize` method per gRPC support type usage, or both if the customizer is gRPC type neutral."
-msgstr "2つの `customize` メソッドがあります。最初のメソッドは gRPC の `ServerBuilder` をパラメータとして使用し、Quarkus のレガシー gRPC サポートで使用します。もう一方は `GrpcServerOptions` を使用し、新しい Vert.x gRPC サポートで使用します。ユーザーは、gRPCサポートタイプの使用法ごとに適切な `customize` メソッドを実装する必要があります。カスタマイザーがgRPCタイプに依存しない場合は、その両方を実装する必要があります。"
+msgstr "`customize` メソッドは2つあり、1つは gRPC の `ServerBuilder` をパラメーターとして使用し、Quarkus のレガシー gRPC サポートで使用されます。もう1つは `GrpcServerOptions` を使用し、新しい Vert.x gRPC サポートで使用されます。ユーザーは、gRPC サポートタイプの使用に応じて適切な `customize` メソッドを実装するか、カスタマイザーが gRPC タイプに依存しない場合は両方を実装する必要があります。"
 
 #. type: Title =
 #: _guides/grpc-service-implementation.adoc
@@ -355,12 +355,12 @@ msgid ""
 msgstr "最高の優先度を持つインターセプターが最初に呼び出されます。インターセプターが `Prioritized` インターフェイスを実装していない場合に使用されるデフォルトの優先度は `0` です。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/grpc-service-implementation.adoc
-#, fuzzy
 msgid ""
 "There is also a support to inject Vert.x `RoutingContext` instance into your gRPC service, if / when needed.\n"
 "Quarkus doesn't do that by default, you will need to add `RoutingContextGrpcInterceptor` to your gRPC service."
-msgstr "また、必要に応じて、gRPCサービスにVert.x `RoutingContext` インスタンスを注入することもできます。Quarkusはデフォルトではこの機能をサポートしていないため、gRPCサービスに `RoutingContextGrpcInterceptor` 。"
+msgstr "必要に応じて、Vert.x の `RoutingContext` インスタンスを gRPC サービスに注入するサポートもあります。Quarkus はデフォルトではこれを実行しないため、`RoutingContextGrpcInterceptor` を gRPC サービスに追加する必要があります。"
 
 #. type: Title =
 #: _guides/grpc-service-implementation.adoc

--- a/l10n/po/ja_JP/_guides/lifecycle.adoc.po
+++ b/l10n/po/ja_JP/_guides/lifecycle.adoc.po
@@ -310,13 +310,13 @@ msgid "The bean is created and the `init()` method is invoked upon the contextua
 msgstr "アプリケーションが起動すると、Bean が作成され、コンテキストインスタンスに対して `init()` メソッドが呼び出されます。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/lifecycle.adoc
-#, fuzzy
 msgid ""
 "The bean is created and the `initReactive()` method is invoked upon the contextual instance when the application\n"
 "starts, on a non-blocking thread, which requires the Quarkus Vert.x extension (there will be an error if it is not\n"
 "present)."
-msgstr "アプリケーションが起動すると、Bean が作成され、 `initReactive()` メソッドがコンテキストインスタンスに対して非ブロッキングスレッドで呼び出されます。このためには、Quarkus Vert.x 拡張モジュールが必要です（存在しない場合はエラーになります）。"
+msgstr "アプリケーションが起動すると、Bean が作成され、Quarkus Vert.x エクステンションを必要とする非ブロッキングスレッドで、コンテキストインスタンスに対して `initReactive()` メソッドが呼び出されます（存在しない場合はエラーになります）。"
 
 #. type: Title ==
 #: _guides/lifecycle.adoc
@@ -425,29 +425,29 @@ msgstr ""
 "デフォルトでは設定されていないため、遅延は適用されません。"
 
 #. type: Title ==
+#. mt: gemini
 #: _guides/lifecycle.adoc
-#, fuzzy
 msgid "Using `@ShutdownDelayInitiated` to execute a business method of a CDI bean when Quarkus shutdown delay initiates"
-msgstr "`@ShutdownDelayInitiated` を使用して、Quarkus のシャットダウン遅延が開始したときに、CDI Bean のビジネスメソッドを実行します。"
+msgstr "`@ShutdownDelayInitiated` を使用した Quarkus シャットダウン遅延開始時の CDI Bean のビジネスメソッド実行"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/lifecycle.adoc
-#, fuzzy
 msgid ""
 "The `@io.quarkus.runtime.ShutdownDelayInitiated` annotation is used to mark a business method of a CDI bean that should be executed when the shutdown delay initiates.\n"
 "The annotated method must be non-private and non-static and declare no arguments. Furthermore, `quarkus.shutdown.delay-enabled` configuration needs to be set to `true`."
-msgstr "`@io.quarkus.runtime.ShutdownDelayInitiated` アノテーションは、シャットダウン遅延が開始したときに実行されるべき CDI Bean のビジネスメソッドをマークするために使用されます。アノテーションされたメソッドは、非プライベートかつ非静的で、引数を宣言しない必要があります。さらに、 `quarkus.shutdown.delay-enabled` 構成を `true` に設定する必要があります。"
+msgstr "`@io.quarkus.runtime.ShutdownDelayInitiated` アノテーションは、シャットダウン遅延が開始されるときに実行されるべき CDI Bean のビジネスメソッドをマークするために使用されます。アノテーションされたメソッドは、非プライベート、非静的であり、引数を宣言しない必要があります。さらに、`quarkus.shutdown.delay-enabled` 設定を `true` に設定する必要があります。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/lifecycle.adoc
-#, fuzzy
 msgid "Declared `@ShutdownDelayInitiated` methods are always executed and as such may block the shutdown procedure."
-msgstr "宣言された `@ShutdownDelayInitiated` メソッドは常に実行されるため、シャットダウン手順をブロックする可能性があります。"
+msgstr "宣言された `@ShutdownDelayInitiated` メソッドは常に実行され、シャットダウン手順をブロックする可能性があります。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/lifecycle.adoc
-#, fuzzy
 msgid ""
 "The behavior is similar to a declaration of a `ShutdownDelayInitiatedEvent` observer.\n"
 "The following examples are functionally equivalent."
-msgstr "動作は `ShutdownDelayInitiatedEvent` オブザーバーの宣言に似ています。以下の例は機能的に同等です。"
+msgstr "この動作は、`ShutdownDelayInitiatedEvent` オブザーバーの宣言に似ています。以下の例は機能的に同等です。"

--- a/l10n/po/ja_JP/_guides/opentelemetry-logging.adoc.po
+++ b/l10n/po/ja_JP/_guides/opentelemetry-logging.adoc.po
@@ -16,16 +16,16 @@ msgid "Using OpenTelemetry Logging"
 msgstr "OpenTelemetry Loggingの使用"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/opentelemetry-logging.adoc
-#, fuzzy
 msgid "<a class=\"status-label status-preview\" title=\"This extension's backward compatibility and presence in the ecosystem is not guaranteed\" href=\"#extension-status-note\">preview</a>"
-msgstr "<a class=\"status-label status-preview\" title=\"この拡張機能の下位互換性とエコシステム内での存在は保証されていません\" href=\"#extension-status-note\">プレビュー</a>"
+msgstr "<a class=\"status-label status-preview\" title=\"このエクステンションの後方互換性およびエコシステムにおける存在は保証されません\" href=\"#extension-status-note\">プレビュー</a>"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/opentelemetry-logging.adoc
-#, fuzzy
 msgid "This guide explains how your Quarkus application can utilize https://opentelemetry.io/[OpenTelemetry] (OTel) to provide structured, contextual, vendor-neutral and centralised logging for interactive web applications."
-msgstr "このガイドでは、Quarkusアプリケーションが link:https://opentelemetry.io/[OpenTelemetry] (OTel)を利用して、インタラクティブなWebアプリケーションに、構造化された、コンテキストに沿った、ベンダーニュートラルな、一元化されたロギングを提供する方法について説明します。"
+msgstr "このガイドでは、Quarkusアプリケーションで https://opentelemetry.io/[OpenTelemetry] (OTel) を利用して、インタラクティブなWebアプリケーション向けに構造化され、コンテキストに応じ、ベンダーに依存しない、一元化されたロギングを提供する方法について説明します。"
 
 #. type: Plain text
 #: _guides/opentelemetry-logging.adoc
@@ -53,10 +53,10 @@ msgid "Architecture"
 msgstr "アーキテクチャ"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/opentelemetry-logging.adoc
-#, fuzzy
 msgid "In this guide, we create a straightforward REST application to demonstrate OTel logging, in a similar way to the other OpenTelemetry signal guides."
-msgstr "このガイドでは、他の OpenTelemetry シグナルガイドと同様の方法で、OTel ロギングを実証するための簡単な REST アプリケーションを作成します。"
+msgstr "このガイドでは、他のOpenTelemetryシグナルガイドと同様に、OTelロギングを実証するための簡単なRESTアプリケーションを作成します。"
 
 #. type: Title =
 #: _guides/opentelemetry-logging.adoc
@@ -182,28 +182,28 @@ msgid "To configure the connection using the same properties for all signals, pl
 msgstr "すべての信号に対して同じプロパティーを使用して接続を設定するには、ベースの xref:opentelemetry.adoc#create-the-configuration[OpenTelemetry ガイドの設定セクション] を確認してください。"
 
 #. type: Title ===
+#. mt: gemini
 #: _guides/opentelemetry-logging.adoc
-#, fuzzy
 msgid "Setting the log level"
 msgstr "ログレベルの設定"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/opentelemetry-logging.adoc
-#, fuzzy
 msgid "By default all log levels are exported."
 msgstr "デフォルトでは、すべてのログレベルがエクスポートされます。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/opentelemetry-logging.adoc
-#, fuzzy
 msgid "If the following configuration is created in the the `application.properties` file, only logs with a level of `ERROR` or higher will be exported:"
-msgstr "`application.properties` ファイルに以下の設定が作成されている場合、 `ERROR` 以上のレベルのログのみがエクスポートされます："
+msgstr "`application.properties` ファイルに以下の設定が作成されている場合、`ERROR` レベル以上のログのみがエクスポートされます。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/opentelemetry-logging.adoc
-#, fuzzy
 msgid "As in other logs in Quarkus, log levels can be set to xref:logging.adoc#use-log-levels[these values]."
-msgstr "Quarkusの他のログと同様に、ログレベルは xref:logging.adoc#use-log-levels[これらの値に] 設定できます。"
+msgstr "Quarkus の他のログと同様に、ログレベルは xref:logging.adoc#use-log-levels[これらの値] に設定可能です。"
 
 #. type: Title =
 #: _guides/opentelemetry-logging.adoc

--- a/l10n/po/ja_JP/_guides/quarkus-maven-plugin.adoc.po
+++ b/l10n/po/ja_JP/_guides/quarkus-maven-plugin.adoc.po
@@ -28,148 +28,134 @@ msgid "Lifecycle"
 msgstr "ライフサイクル"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/quarkus-maven-plugin.adoc
-#, fuzzy
 msgid ""
 "The Quarkus Maven Plugin provides a specific `quarkus` packaging that is used by default in the generated projects.\n"
 "This packaging should be used only for the Quarkus application itself, not for the library modules that should keep the default `jar` packaging."
-msgstr "Quarkus Maven Pluginは、生成されたプロジェクトでデフォルトで使用される特定の `quarkus` パッケージングを提供します。このパッケージングは、Quarkusアプリケーション自体にのみ使用され、デフォルトの `jar` パッケージングを維持するライブラリモジュールには使用されません。"
+msgstr "Quarkus Maven プラグインは、生成されたプロジェクトでデフォルトで使用される特定の `quarkus` パッケージングを提供します。このパッケージングは、Quarkus アプリケーション自体にのみ使用し、デフォルトの `jar` パッケージングを維持する必要があるライブラリモジュールには使用しないでください。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/quarkus-maven-plugin.adoc
-#, fuzzy
 msgid "This `quarkus` packaging defines a specific default lifecycle:"
-msgstr "この `quarkus` パッケージは、特定のデフォルトのライフサイクルを定義します："
+msgstr "この `quarkus` パッケージングは、特定のデフォルトライフサイクルを定義します。"
 
 #. type: Table
+#. mt: gemini
 #: _guides/quarkus-maven-plugin.adoc
-#, fuzzy
 msgid "Phase"
 msgstr "フェーズ"
 
 #. type: Table
+#. mt: gemini
 #: _guides/quarkus-maven-plugin.adoc
-#, fuzzy
 msgid "Executions"
-msgstr "死刑執行"
+msgstr "実行"
 
 #. type: Table
+#. mt: gemini
 #: _guides/quarkus-maven-plugin.adoc
-#, fuzzy
 msgid "process-resources"
-msgstr "プロセス-リソース"
+msgstr "process-resources"
 
 #. type: Table
+#. mt: gemini
 #: _guides/quarkus-maven-plugin.adoc
-#, fuzzy
 msgid ""
 "* `maven-resources-plugin:resources`\n"
 "* `quarkus-maven-plugin:generate-code`"
 msgstr ""
-"\n"
-" `maven-resources-plugin:resources`\n"
-"\n"
-" `quarkus-maven-plugin:generate-code`"
+"* `maven-resources-plugin:resources`\n"
+"* `quarkus-maven-plugin:generate-code`"
 
 #. type: Table
+#. mt: gemini
 #: _guides/quarkus-maven-plugin.adoc
-#, fuzzy
 msgid "compile"
-msgstr "コンパイル"
+msgstr "compile"
 
 #. type: Table
+#. mt: gemini
 #: _guides/quarkus-maven-plugin.adoc
-#, fuzzy
 msgid "* `maven-compiler-plugin:compile`"
-msgstr ""
-"\n"
-" `maven-compiler-plugin:compile`"
+msgstr "* `maven-compiler-plugin:compile`"
 
 #. type: Table
+#. mt: gemini
 #: _guides/quarkus-maven-plugin.adoc
-#, fuzzy
 msgid "process-test-resources"
-msgstr "プロセステストリソース"
+msgstr "process-test-resources"
 
 #. type: Table
+#. mt: gemini
 #: _guides/quarkus-maven-plugin.adoc
-#, fuzzy
 msgid ""
 "* `maven-resources-plugin:testResources`\n"
 "* `quarkus-maven-plugin:generate-code-tests`"
 msgstr ""
-"\n"
-" `maven-resources-plugin:testResources`\n"
-"\n"
-" `quarkus-maven-plugin:generate-code-tests`"
+"* `maven-resources-plugin:testResources`\n"
+"* `quarkus-maven-plugin:generate-code-tests`"
 
 #. type: Table
+#. mt: gemini
 #: _guides/quarkus-maven-plugin.adoc
-#, fuzzy
 msgid "test-compile"
-msgstr "テストコンパイル"
+msgstr "test-compile"
 
 #. type: Table
+#. mt: gemini
 #: _guides/quarkus-maven-plugin.adoc
-#, fuzzy
 msgid "* `maven-compiler-plugin:testCompile`"
-msgstr ""
-"\n"
-" `maven-compiler-plugin:testCompile`"
+msgstr "* `maven-compiler-plugin:testCompile`"
 
 #. type: Table
+#. mt: gemini
 #: _guides/quarkus-maven-plugin.adoc
-#, fuzzy
 msgid "test"
-msgstr "テスト"
+msgstr "test"
 
 #. type: Table
+#. mt: gemini
 #: _guides/quarkus-maven-plugin.adoc
-#, fuzzy
 msgid "* `maven-surefire-plugin:test`"
-msgstr ""
-"\n"
-" `maven-surefire-plugin:test`"
+msgstr "* `maven-surefire-plugin:test`"
 
 #. type: Table
+#. mt: gemini
 #: _guides/quarkus-maven-plugin.adoc
-#, fuzzy
 msgid "package"
-msgstr "パッケージ"
+msgstr "package"
 
 #. type: Table
+#. mt: gemini
 #: _guides/quarkus-maven-plugin.adoc
-#, fuzzy
 msgid "* `quarkus-maven-plugin:build`"
-msgstr ""
-"\n"
-" `quarkus-maven-plugin:build`"
+msgstr "* `quarkus-maven-plugin:build`"
 
 #. type: Table
+#. mt: gemini
 #: _guides/quarkus-maven-plugin.adoc
-#, fuzzy
 msgid "post-integration-test"
-msgstr "統合後テスト"
+msgstr "post-integration-test"
 
 #. type: Table
+#. mt: gemini
 #: _guides/quarkus-maven-plugin.adoc
-#, fuzzy
 msgid "* `quarkus-maven-plugin:native-image-agent`"
-msgstr ""
-"\n"
-" `quarkus-maven-plugin:native-image-agent`"
+msgstr "* `quarkus-maven-plugin:native-image-agent`"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/quarkus-maven-plugin.adoc
-#, fuzzy
 msgid "You can tweak the lifecycle either by not using the `quarkus` packaging or by configuring the default execution."
-msgstr "`quarkus` パッケージングを使用しないか、デフォルトの実行を設定することで、ライフサイクルを微調整することができます。"
+msgstr "ライフサイクルは、 `quarkus` パッケージングを使用しないか、デフォルトの実行を設定することで調整できます。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/quarkus-maven-plugin.adoc
-#, fuzzy
 msgid "For instance, if you want to disable the `quarkus:build` goal for a specific module:"
-msgstr "例えば、特定のモジュールの `quarkus:build` 目標を無効にしたい場合："
+msgstr "例えば、特定のモジュールで `quarkus:build` ゴールを無効にしたい場合は次のようになります。"
 
 #. type: Title =
 #: _guides/quarkus-maven-plugin.adoc

--- a/l10n/po/ja_JP/_guides/quarkus-runtime-base-image.adoc.po
+++ b/l10n/po/ja_JP/_guides/quarkus-runtime-base-image.adoc.po
@@ -66,25 +66,25 @@ msgid "Extending the image"
 msgstr "イメージの拡張"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/quarkus-runtime-base-image.adoc
-#, fuzzy
 msgid ""
 "Your application may have additional requirements.\n"
 "For example, if you have an application that manipulates graphics, images, or PDFs, you likely have Quarkus AWT extension included in the project and your native executable will require some additional libraries to run.\n"
 "In this case, you need to use a multi-stage `dockerfile` to copy the required libraries."
-msgstr "アプリケーションには追加の要件があるかもしれません。たとえば、グラフィック、画像、PDFを操作するアプリケーションの場合、プロジェクトにQuarkus AWT拡張機能が含まれている可能性が高く、ネイティブ実行ファイルを実行するには、追加のライブラリが必要になります。この場合、マルチステージ `dockerfile` 、必要なライブラリをコピーする必要があります。"
+msgstr "お使いのアプリケーションに追加の要件がある場合があります。たとえば、グラフィック、画像、または PDF を操作するアプリケーションがある場合、プロジェクトに Quarkus AWT エクステンションが含まれており、ネイティブ実行可能ファイルの実行には追加のライブラリーが必要になる可能性があります。この場合、マルチステージの `dockerfile` を使用して、必要なライブラリーをコピーする必要があります。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/quarkus-runtime-base-image.adoc
-#, fuzzy
 msgid "Copying handpicked libraries makes up for a small container image, yet it is somewhat britte, differs for different base image versions, and it is a subject to change as transitive dependencies of these libraries might change."
-msgstr "厳選されたライブラリをコピーすることで、小さなコンテナイメージを構成することができますが、多少面倒で、ベースイメージのバージョンによって異なり、これらのライブラリの推移的依存関係が変更される可能性があるため、変更される可能性があります。"
+msgstr "厳選されたライブラリーをコピーすると、コンテナーイメージは小さくなりますが、やや脆弱であり、ベースイメージのバージョンによって異なり、これらのライブラリーの移行的依存関係が変更される可能性があるため、変更される可能性があります。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/quarkus-runtime-base-image.adoc
-#, fuzzy
 msgid "Headless graphics, PDF documents, QR code images etc. manipulation is natively supported on amd64/aarch64 Linux only. Neither Windows nor MacOS are supported and require running the application in a Linux container."
-msgstr "ヘッドレスグラフィックス、PDF文書、QRコード画像などの操作は、amd64/aarch64 Linuxでのみネイティブにサポートされています。WindowsとMacOSはサポートされておらず、Linuxコンテナ内でアプリケーションを実行する必要があります。"
+msgstr "ヘッドレスグラフィックス、PDF ドキュメント、QR コード画像などの操作は、amd64/aarch64 Linux のみでネイティブにサポートされています。Windows も MacOS もサポートされておらず、Linux コンテナーでアプリケーションを実行する必要があります。"
 
 #. type: Title =
 #: _guides/quarkus-runtime-base-image.adoc
@@ -108,7 +108,7 @@ msgid "To use this base image, use the following `Dockerfile`:"
 msgstr "このベースイメージを使用するには、以下の `Dockerfile` を使用します:"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/quarkus-runtime-base-image.adoc
-#, fuzzy
 msgid "To make documents processing, graphics, PDFs, etc. available for the application, you can install the required libraries using `microdnf` without manually copying anything:"
-msgstr "ドキュメント処理、グラフィック、PDFなどをアプリケーションで利用できるようにするには、手動で何もコピーしなくても、 `microdnf` を使って必要なライブラリをインストールできます："
+msgstr "ドキュメント処理、グラフィック、PDF などをアプリケーションで利用できるようにするには、何も手動でコピーすることなく `microdnf` を使用して必要なライブラリーをインストールできます:"

--- a/l10n/po/ja_JP/_guides/rabbitmq-reference.adoc.po
+++ b/l10n/po/ja_JP/_guides/rabbitmq-reference.adoc.po
@@ -20,10 +20,10 @@ msgid "Reactive Messaging RabbitMQ Connector Reference Documentation"
 msgstr "リアクティブメッセージング RabbitMQ コネクターのリファレンスドキュメント"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/rabbitmq-reference.adoc
-#, fuzzy
 msgid "<a class=\"status-label status-preview\" title=\"This extension's backward compatibility and presence in the ecosystem is not guaranteed\" href=\"#extension-status-note\">preview</a>"
-msgstr "<a class=\"status-label status-preview\" title=\"この拡張機能の下位互換性とエコシステム内での存在は保証されていません\" href=\"#extension-status-note\">プレビュー</a>"
+msgstr "<a class=\"status-label status-preview\" title=\"このエクステンションの後方互換性およびエコシステムにおける存在は保証されません\" href=\"#extension-status-note\">プレビュー</a>"
 
 #. type: Plain text
 #: _guides/rabbitmq-reference.adoc
@@ -47,14 +47,14 @@ msgid ""
 msgstr "RabbitMQ コネクターを使用すると、Quarkus アプリケーションは AMQP 0.9.1 プロトコルを使用してメッセージを送受信できます。プロトコルの詳細については、 https://www.rabbitmq.com/amqp-0-9-1-reference.html#queue.bind.routing-key[AMQP 0.9.1 の仕様書] を参照してください。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/rabbitmq-reference.adoc
-#, fuzzy
 msgid ""
 "The RabbitMQ connector is specifically designed for AMQP 0-9-1.\n"
 "While RabbitMQ 4 now supports the AMQP 1.0 protocol, the two protocols are fundamentally different.\n"
 "If you want to communicate with RabbitMQ using AMQP 1.0, we recommend using the xref:amqp-reference.adoc[AMQP 1.0 connector].\n"
 "Please note that using AMQP 1.0 with RabbitMQ may still have some limitations or reduced functionality compared to native 0-9-1 usage."
-msgstr "RabbitMQコネクタはAMQP 0-9-1専用に設計されています。RabbitMQ 4はAMQP 1.0プロトコルをサポートするようになりましたが、この2つのプロトコルは基本的に異なります。AMQP 1.0 を使用して RabbitMQ と通信する場合は、 xref:amqp-reference.adoc[AMQP 1.0 コネクタを] 使用することをお勧めします。RabbitMQでAMQP 1.0を使用する場合、ネイティブの0-9-1使用と比較して、いくつかの制限や機能低下が発生する可能性があることにご注意ください。"
+msgstr "RabbitMQ コネクターは、AMQP 0-9-1 専用に設計されています。RabbitMQ 4 は現在 AMQP 1.0 プロトコルをサポートしていますが、これら 2 つのプロトコルは根本的に異なります。AMQP 1.0 を使用して RabbitMQ と通信したい場合は、xref:amqp-reference.adoc[AMQP 1.0 コネクター] を使用することをお勧めします。RabbitMQ で AMQP 1.0 を使用する場合、ネイティブの 0-9-1 の使用と比較して、まだいくつかの制限や機能の低下がある可能性があることに注意してください。"
 
 #. type: Title =
 #: _guides/rabbitmq-reference.adoc
@@ -304,10 +304,10 @@ msgid "`fail` - fail the application; no more RabbitMQ messages will be processe
 msgstr "`fail` - アプリケーションは失敗し、これ以上 RabbitMQ メッセージは処理されません。RabbitMQ メッセージは拒否済みとしてマークされます。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/rabbitmq-reference.adoc
-#, fuzzy
 msgid "`accept` - this strategy marks the RabbitMQ message as _accepted_. The processing continues, ignoring the failure."
-msgstr "`accept` - このストラテジーはRabbitMQメッセージを _受理した_ ものとしてマークします。処理は失敗を無視して続行されます。"
+msgstr "`accept` - この戦略は、RabbitMQ メッセージを _承認済み_ としてマークします。処理は失敗を無視して続行します。"
 
 #. type: Plain text
 #: _guides/rabbitmq-reference.adoc
@@ -559,13 +559,13 @@ msgid "On the outbound side (sending records to RabbitMQ), the check verifies th
 msgstr "アウトバウンド側 (RabbitMQ にレコードを送信) では、チェックにより、送信者がブローカーから切断されていないことを確認します。送信者は初期化された状態 (接続は未試行) の_可能性_がありますが、これはlive/ready と見なされます。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/rabbitmq-reference.adoc
-#, fuzzy
 msgid ""
 "Note that a message processing failure nacks the message, which is then handled by the `failure-strategy`.\n"
 "It's the responsibility of the `failure-strategy` to report the failure and influence the outcome of the checks.\n"
 "The `fail` failure strategy reports the failure, and so the check will report the fault."
-msgstr "メッセージ処理に失敗すると、そのメッセージは `failure-strategy` で処理されます。失敗を報告し、チェックの結果に影響を与えるのは `failure-strategy` の責任です。 `fail` 失敗ストラテジーは失敗を報告するので、チェックは失敗を報告します。"
+msgstr "メッセージ処理の失敗はメッセージを nack し、それは `failure-strategy` によって処理されることに注意してください。失敗を報告し、チェックの結果に影響を与えるのは `failure-strategy` の責任です。`fail` 失敗戦略は失敗を報告するため、チェックも失敗を報告します。"
 
 #. type: Title =
 #: _guides/rabbitmq-reference.adoc

--- a/l10n/po/ja_JP/_guides/rest-data-panache.adoc.po
+++ b/l10n/po/ja_JP/_guides/rest-data-panache.adoc.po
@@ -27,10 +27,10 @@ msgid ""
 msgstr "多くのWebアプリケーションは、REST APIを使った単調なCRUDアプリケーションで、書くのが面倒です。このタスクを合理化するために、REST Data with Panache エクステンションは、エンティティーやリポジトリの基本的なCRUDエンドポイントを生成することができます。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/rest-data-panache.adoc
-#, fuzzy
 msgid "Currently, this extension supports Hibernate ORM and MongoDB with Panache and can generate CRUD resources that work with `application/json` and `application/hal+json` content and generates REST Resources backed by Quarkus REST."
-msgstr "現在、この拡張機能はHibernate ORMとMongoDB with Panacheをサポートしており、 `application/json` 、 `application/hal+json` コンテンツで動作するCRUDリソースを生成し、Quarkus RESTでバックアップされたRESTリソースを生成できます。"
+msgstr "このエクステンションは現在、Hibernate ORM と MongoDB with Panache をサポートしており、 `application/json` および `application/hal+json` コンテンツで動作する CRUD リソースを生成し、Quarkus REST に支えられた REST リソースを生成できます。"
 
 #. type: Title =
 #: _guides/rest-data-panache.adoc
@@ -127,10 +127,10 @@ msgid "A JDBC driver extension (`quarkus-jdbc-postgresql`, `quarkus-jdbc-h2`, `q
 msgstr "JDBC ドライバーエクステンション ( `quarkus-jdbc-postgresql` , `quarkus-jdbc-h2` , `quarkus-jdbc-mariadb` , ...)"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/rest-data-panache.adoc
-#, fuzzy
 msgid "One of the REST JSON serialization extensions (such as `quarkus-rest-jackson`)"
-msgstr "REST JSONシリアライゼーション拡張のひとつ（ `quarkus-rest-jackson` など）。"
+msgstr "REST JSON シリアライゼーションエクステンションの 1 つ (例: `quarkus-rest-jackson`)"
 
 #. type: Block title
 #: _guides/rest-data-panache.adoc
@@ -413,46 +413,46 @@ msgid "Additionally, if you are only interested in specifying the roles that are
 msgstr "さらに、リソースの使用が許可されているロールの指定にのみ関心がある場合、 `@ResourceProperties` および `@MethodProperties` のアノテーションには、リソースまたは操作へのアクセスが許可されているセキュリティロールをリストアップするフィールド `rolesAllowed` があります。"
 
 #. type: Title ==
+#. mt: gemini
 #: _guides/rest-data-panache.adoc
-#, fuzzy
 msgid "Using @Authenticated"
-msgstr "認証済み"
+msgstr "`@Authenticated` の使用"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/rest-data-panache.adoc
-#, fuzzy
 msgid "Additionally, REST Data with Panache can be used in conjunction with `io.quarkus.security.Authenticated`, by either:"
-msgstr "さらに、REST Data with Panache は `io.quarkus.security.Authenticated` と併用することができます："
+msgstr "さらに、REST Data with Panache は `io.quarkus.security.Authenticated` と組み合わせて、次のいずれかの方法で使用できます。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/rest-data-panache.adoc
-#, fuzzy
 msgid "Setting `@ResourceProperties(authenticated=true)` which results in all methods of the resource requiring authentication"
-msgstr "`@ResourceProperties(authenticated=true)` を設定すると、リソースのすべてのメソッドで認証が必要になります。"
+msgstr "`@ResourceProperties(authenticated=true)` を設定することで、リソースのすべてのメソッドが認証を必要とするようになります。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/rest-data-panache.adoc
-#, fuzzy
 msgid "The same result can also be achieved by adding the `@Authenticated` annotation on the interface instead of using the `authenticated` property"
-msgstr "`authenticated` プロパティを使う代わりに、 `@Authenticated` アノテーションをインターフェイスに追加することでも、同じ結果が得られます。"
+msgstr "同じ結果は、 `authenticated` プロパティーを使用する代わりに、インターフェースに `@Authenticated` アノテーションを追加することでも実現できます。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/rest-data-panache.adoc
-#, fuzzy
 msgid "Finally, the `@Authenticated` annotation can be used on specific methods, meaning that only those will require an authenticated user. An example might look like so:"
-msgstr "最後に、 `@Authenticated` アノテーションを特定のメソッドに使用することで、そのメソッドでのみ認証ユーザーを必要とするようにすることができます。例を示します："
+msgstr "最後に、 `@Authenticated` アノテーションは特定のメソッドで使用でき、その場合、それらのメソッドのみが認証されたユーザーを必要とします。例は次のようになります。"
 
 #. type: Title ==
+#. mt: gemini
 #: _guides/rest-data-panache.adoc
-#, fuzzy
 msgid "Securing endpoints using @PermissionsAllowed annotation"
-msgstr "PermissionsAllowedアノテーションを使用したエンドポイントの保護"
+msgstr "`@PermissionsAllowed` アノテーションを使用したエンドポイントの保護"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/rest-data-panache.adoc
-#, fuzzy
 msgid "You can also secure your endpoints with the `@PermissionsAllowed` security annotation like in the example below:"
-msgstr "以下の例のように、 `@PermissionsAllowed` セキュリティ注釈を使用してエンドポイントを保護することもできます："
+msgstr "また、以下の例のように、 `@PermissionsAllowed` セキュリティーアノテーションを使用してエンドポイントを保護することもできます。"
 
 #. type: Title =
 #: _guides/rest-data-panache.adoc

--- a/l10n/po/ja_JP/_guides/scheduler-reference.adoc.po
+++ b/l10n/po/ja_JP/_guides/scheduler-reference.adoc.po
@@ -41,14 +41,14 @@ msgid "Scheduled Methods"
 msgstr "スケジュールされたメソッド"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/scheduler-reference.adoc
-#, fuzzy
 msgid ""
 "A method annotated with `@io.quarkus.scheduler.Scheduled` is automatically scheduled for invocation.\n"
 "A scheduled method must not be abstract or private.\n"
 "It may be either static or non-static.\n"
 "A scheduled method can be annotated with interceptor bindings, such as `@jakarta.transaction.Transactional`."
-msgstr "`@io.quarkus.scheduler.Scheduled` でアノテーションされたメソッドは、自動的にスケジュールされます。スケジュールされたメソッドは抽象メソッドやプライベートメソッドであってはなりません。また、静的でも非静的でもかまいません。スケジュールされたメソッドは、 `@jakarta.transaction.Transactional` のようなインターセプター・バインディングでアノテーションすることができます。"
+msgstr "`@io.quarkus.scheduler.Scheduled` でアノテーションされたメソッドは、自動的に呼び出しがスケジュールされます。スケジュールされたメソッドは、abstract または private であってはなりません。静的または非静的のいずれでもかまいません。スケジュールされたメソッドには、`@jakarta.transaction.Transactional` のようなインターセプターバインディングをアノテーションできます。"
 
 #. type: Plain text
 #: _guides/scheduler-reference.adoc
@@ -837,42 +837,42 @@ msgstr ""
 "詳細については、 xref:./virtual-threads.adoc[仮想スレッドガイド] をお読みください。"
 
 #. type: Title =
+#. mt: gemini
 #: _guides/scheduler-reference.adoc
-#, fuzzy
 msgid "Assign a user and roles to a scheduled task"
 msgstr "スケジュールされたタスクへのユーザーとロールの割り当て"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/scheduler-reference.adoc
-#, fuzzy
 msgid ""
 "You can use the `@RunAsUser` annotation on methods annotated with the `@Scheduled` annotation to configure the `SecurityIdentity` for the task execution.\n"
 "The `@RunAsUser` annotation works only for the scheduled tasks."
-msgstr "`@Scheduled` アノテーションでアノテートされたメソッドで `@RunAsUser` アノテーションを使用すると、タスク実行用に `SecurityIdentity` を構成できます。 `@RunAsUser` アノテーションは、スケジュールされたタスクに対してのみ機能します。"
+msgstr "`@Scheduled` アノテーションが付けられたメソッドでは、`@RunAsUser` アノテーションを使用してタスク実行の `SecurityIdentity` を設定できます。`@RunAsUser` アノテーションは、スケジュールされたタスクでのみ機能します。"
 
 #. type: Block title
+#. mt: gemini
 #: _guides/scheduler-reference.adoc
-#, fuzzy
 msgid "Example scheduled task with `@RunAsUser`"
-msgstr "スケジュールされたタスクの例 `@RunAsUser`"
+msgstr "`@RunAsUser` を使用したスケジュールタスクの例"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/scheduler-reference.adoc
-#, fuzzy
 msgid "Assign the user `Alice` to the scheduled `updateTask`."
-msgstr "スケジュールされた `updateTask` にユーザー `Alice` を割り当てます。"
+msgstr "ユーザー `Alice` をスケジュールされた `updateTask` に割り当てます。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/scheduler-reference.adoc
-#, fuzzy
 msgid "The call to the `MyService#update` method succeeds, because the configured user has role `admin`."
-msgstr "`MyService#update` メソッドの呼び出しは、設定されたユーザーがロール `admin` を持っているため、成功します。"
+msgstr "`MyService#update` メソッドの呼び出しは成功します。これは、設定されたユーザーが `admin` ロールを持っているためです。"
 
 #. type: Plain text
+#. mt: gemini
 #: _guides/scheduler-reference.adoc
-#, fuzzy
 msgid "The `@RunAsUser` annotation creates an identity for scheduled tasks. It does not temporarily replace the current identity."
-msgstr "`@RunAsUser` アノテーションは、スケジュールされたタスクの ID を作成します。これは、現在の ID を一時的に置き換えるものではありません。"
+msgstr "`@RunAsUser` アノテーションは、スケジュールされたタスクの ID を作成します。現在の ID を一時的に置き換えることはありません。"
 
 #. type: Title =
 #: _guides/scheduler-reference.adoc


### PR DESCRIPTION
## Summary
Retranslated fuzzy messages in 10 guides from the bottom of the CSV list.

## Files Retranslated
1. quarkus-runtime-base-image.adoc.po (4 fuzzy messages)
2. rabbitmq-reference.adoc.po (4 fuzzy messages)
3. grpc-service-implementation.adoc.po (4 fuzzy messages)
4. rest-data-panache.adoc.po (9 fuzzy messages)
5. lifecycle.adoc.po (5 fuzzy messages)
6. container-image.adoc.po (5 fuzzy messages)
7. scheduler-reference.adoc.po (7 fuzzy messages)
8. opentelemetry-logging.adoc.po (7 fuzzy messages)
9. deploying-to-openshift-s2i-howto.adoc.po (12 fuzzy messages)
10. quarkus-maven-plugin.adoc.po (20 fuzzy messages)

**Total: 77 fuzzy messages retranslated**