### PR TITLE
Update documentation for --asciidoc option rename

### DIFF
--- a/internal/docs/translation-quality-comparison/README.md
+++ b/internal/docs/translation-quality-comparison/README.md
@@ -13,7 +13,7 @@
   - tsujiツールでGemini（OpenAI互換API経由）を使用して翻訳
   - 翻訳時間: 425秒（約7分）
   - サイズ: 257KB
-  - コマンド: `./tsujiw po machine-translate --isAsciidoc -p <file>`
+  - コマンド: `./tsujiw po machine-translate --asciidoc -p <file>`
   
 - **deepl.po** - DeepL翻訳版
   - tsujiツールでDeepL APIを使用して翻訳


### PR DESCRIPTION
## Summary

Updated internal documentation to reflect the tsuji CLI option rename from `--isAsciidoc` to `--asciidoc`.

## Changes

- `internal/docs/translation-quality-comparison/README.md`: Updated command examples (2 occurrences)

## Related

- tsuji PR: https://github.com/doc-l10n-kit/tsuji/pull/76