### PR TITLE
Add 14 HTML files to translation extraction list

### DIFF
--- a/config/application.yaml
+++ b/config/application.yaml
@@ -51,9 +51,18 @@ tsuji:
       html:
         include:
           - _includes/about.html
+          - _includes/ai-blueprints.html
+          - _includes/ai-chainofthought.html
+          - _includes/ai-contextualrag.html
+          - _includes/ai-frozenrag.html
+          - _includes/ai-java-for-ai.html
+          - _includes/ai-overview.html
+          - _includes/ai-quarkus-for-ai.html
           - _includes/awards-band.html
+          - _includes/benefactors.html
           - _includes/catalog-detail-band.html
           - _includes/catalog-index-band.html
+          - _includes/CF-footerband.html
           - _includes/community-contrib-band.html
           - _includes/container-first.html
           - _includes/continuum.html
@@ -67,6 +76,7 @@ tsuji:
           - _includes/get-started-code-steps.html
           - _includes/header-navigation.html
           - _includes/header-navigation_full.html
+          - _includes/homepage-commonhaus-band.html
           - _includes/homepage-container_first-band.html
           - _includes/homepage-developer_joy-band.html
           - _includes/homepage-extensions-band.html
@@ -80,10 +90,14 @@ tsuji:
           - _includes/homepage-performance-band.html
           - _includes/homepage-worldtour-band.html
           - _includes/kubernetes-native.html
+          - _includes/newsletter-band.html
           - _includes/performance.html
+          - _includes/spring-features-band.html
+          - _includes/spring-migrate-main.html
           - _includes/standards.html
           - _includes/support-help-band.html
           - _includes/support-options-band.html
+          - _includes/training-band.html
           - _includes/userstories-band.html
           - _includes/worldtour-abstracts.html
           - _includes/worldtour-code.html

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -57,9 +57,9 @@ tsuji:
           - _includes/ai-frozenrag.html
           - _includes/ai-java-for-ai.html
           - _includes/ai-overview.html
-          - _includes/ai-quarkus-for-ai.html
+          # - _includes/ai-quarkus-for-ai.html  # Temporarily excluded due to malformed HTML (upstream issue)
           - _includes/awards-band.html
-          - _includes/benefactors.html
+          # - _includes/benefactors.html  # Temporarily excluded due to malformed HTML (upstream issue)
           - _includes/catalog-detail-band.html
           - _includes/catalog-index-band.html
           - _includes/CF-footerband.html
@@ -92,8 +92,8 @@ tsuji:
           - _includes/kubernetes-native.html
           - _includes/newsletter-band.html
           - _includes/performance.html
-          - _includes/spring-features-band.html
-          - _includes/spring-migrate-main.html
+          # - _includes/spring-features-band.html  # Temporarily excluded due to malformed HTML (upstream issue)
+          # - _includes/spring-migrate-main.html  # Temporarily excluded due to malformed HTML (upstream issue)
           - _includes/standards.html
           - _includes/support-help-band.html
           - _includes/support-options-band.html

--- a/l10n/po/ja_JP/_data/versioned/latest/index/quarkus.yaml.po
+++ b/l10n/po/ja_JP/_data/versioned/latest/index/quarkus.yaml.po
@@ -707,7 +707,6 @@ msgid "security-oidc-expanded-configuration"
 msgstr "security-oidc-expanded-configuration"
 
 #. type: Hash Value: types concepts summary
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "Quarkus OIDC quarkus-oidc extension provides a comprehensive, highly adaptable and configurable OIDC and OAuth2 adapter implementation."
@@ -966,7 +965,6 @@ msgid "aws-lambda-http.adoc"
 msgstr "aws-lambda-http.adoc"
 
 #. type: Hash Value: types reference status
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "preview"
@@ -1045,7 +1043,6 @@ msgid "aot.adoc"
 msgstr "aot.adoc"
 
 #. type: Hash Value: types guide summary
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "This guide explains how to use Leyden AOT caching with Quarkus for dramatically faster startup times on JDK 24+."
@@ -1058,21 +1055,18 @@ msgid "Ahead-of-Time (AOT) Caching"
 msgstr "Ahead-of-Time (AOT) キャッシング"
 
 #. type: Array Element: types guide topics
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "aot"
 msgstr "aot"
 
 #. type: Array Element: types guide topics
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "leyden"
 msgstr "leyden"
 
 #. type: Array Element: types guide topics
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "startup"
@@ -1355,14 +1349,12 @@ msgid "stork-registration.adoc"
 msgstr "stork-registration.adoc"
 
 #. type: Hash Value: types guide summary
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "This guide explains how to enable automatic registration and deregistration of a Quarkus application using SmallRye Stork and Consul, with minimal or no configuration."
 msgstr "このガイドでは、SmallRye Stork と Consul を使用して、最小限の設定または設定なしで Quarkus アプリケーションの自動登録および登録解除を有効にする方法について説明します。"
 
 #. type: Hash Value: types guide title
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "Automatic service registration with SmallRye Stork for Quarkus"
@@ -1375,7 +1367,6 @@ msgid "service-discovery"
 msgstr "service-discovery"
 
 #. type: Array Element: types guide topics
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "consul"
@@ -1730,7 +1721,6 @@ msgid "compose-dev-services.adoc"
 msgstr "compose-dev-services.adoc"
 
 #. type: Hash Value: types guide summary
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "Configure custom Dev Services using Docker or Podman Compose."
@@ -1761,7 +1751,6 @@ msgid "testing"
 msgstr "testing"
 
 #. type: Array Element: types guide topics
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "compose"
@@ -2338,7 +2327,6 @@ msgid "assistant.adoc"
 msgstr "assistant.adoc"
 
 #. type: Hash Value: types guide summary
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "Learn more about the Dev Assistant"
@@ -2351,14 +2339,12 @@ msgid "Dev Assistant"
 msgstr "Dev Assistant"
 
 #. type: Array Element: types guide topics
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "assistant"
 msgstr "assistant"
 
 #. type: Array Element: types guide topics
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "extension"
@@ -2377,7 +2363,6 @@ msgid "dev-mcp.adoc"
 msgstr "dev-mcp.adoc"
 
 #. type: Hash Value: types guide summary
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "Learn more about Dev MCP"
@@ -2390,7 +2375,6 @@ msgid "Dev MCP"
 msgstr "Dev MCP"
 
 #. type: Array Element: types guide topics
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "dev-mcp"
@@ -2751,14 +2735,12 @@ msgid "lra-dev-services.adoc"
 msgstr "lra-dev-services.adoc"
 
 #. type: Hash Value: types guide summary
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "Start the Narayana LRA coordinator automatically in dev and test modes."
 msgstr "開発モードおよびテストモードで Narayana LRA コーディネーターを自動的に起動します。"
 
 #. type: Hash Value: types guide title
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "Dev Services for LRA"
@@ -2879,7 +2861,6 @@ msgid "redis-dev-services.adoc"
 msgstr "redis-dev-services.adoc"
 
 #. type: Hash Value: types reference status
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "stable"
@@ -2916,7 +2897,6 @@ msgid "dev-ui.adoc"
 msgstr "dev-ui.adoc"
 
 #. type: Hash Value: types guide summary
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "Learn more about Dev UI"
@@ -3223,7 +3203,6 @@ msgid "This guide explains Funqy's AWS Lambda HTTP binding."
 msgstr "このガイドでは、FunqyのAWS Lambda HTTPバインディングについて説明します。"
 
 #. type: Hash Value: types guide title
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "Funqy HTTP Binding with AWS Lambda�"
@@ -5374,7 +5353,6 @@ msgid "/guides/hibernate-reactive-panache"
 msgstr "/guides/hibernate-reactive-panache"
 
 #. type: Array Element: types guide extensions
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "io.quarkus:quarkus-hibernate-panache-next"
@@ -5387,21 +5365,18 @@ msgid "hibernate-panache-next.adoc"
 msgstr "hibernate-panache-next.adoc"
 
 #. type: Hash Value: types reference status
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "experimental"
 msgstr "experimental"
 
 #. type: Hash Value: types guide summary
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "Hibernate is the de facto Jakarta Persistence implementation and offers you the full breadth of an Object Relational Mapper."
 msgstr "Hibernate は、デファクトの Jakarta Persistence 実装であり、Object Relational Mapper の全機能を網羅しています。"
 
 #. type: Hash Value: types guide title
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "Simplified Hibernate with Panache Next"
@@ -6032,7 +6007,6 @@ msgid "jfr"
 msgstr "jfr"
 
 #. type: Hash Value: types guide summary
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "This guide explains how JDK Flight Recorder (JFR) can be extended to provide additional insight into your Quarkus application."
@@ -6375,7 +6349,6 @@ msgid "opentelemetry-logging.adoc"
 msgstr "opentelemetry-logging.adoc"
 
 #. type: Hash Value: types guide summary
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "This guide explains how your Quarkus application can utilize OpenTelemetry Logging to provide centralised logging for interactive web applications."
@@ -6478,7 +6451,6 @@ msgid "/guides/podman"
 msgstr "/guides/podman"
 
 #. type: Array Element: types guide extensions
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "io.quarkus:quarkus-proxy-registry"
@@ -6491,21 +6463,18 @@ msgid "proxy-registry.adoc"
 msgstr "proxy-registry.adoc"
 
 #. type: Hash Value: types guide summary
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "This guide explains how to use the Proxy Registry in your Quarkus application."
 msgstr "このガイドでは、Quarkus アプリケーションでプロキシーレジストリーを使用する方法について説明します。"
 
 #. type: Hash Value: types guide title
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "Using Proxy Registry"
 msgstr "プロキシーレジストリーの使用"
 
 #. type: Array Element: types guide topics
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "proxy"
@@ -6800,7 +6769,6 @@ msgid "This guide explains how your Quarkus application can utilize web sockets 
 msgstr "このガイドでは、QuarkusアプリケーションがWeb Socketを利用してインタラクティブなウェブアプリケーションを作成する方法を説明します。"
 
 #. type: Hash Value: types guide title
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "Using WebSockets with Undertow"
@@ -7467,7 +7435,6 @@ msgid "This guide describes how to build and deploy a Quarkus application on Ope
 msgstr "このガイドでは、Dockerビルドストラテジーを使用してOpenShift上でQuarkusアプリケーションをビルドしてデプロイする方法を説明します。"
 
 #. type: Hash Value: types howto title
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "Deploying Quarkus Java applications to OpenShift by using a Docker build strategy"
@@ -7492,14 +7459,12 @@ msgid "deploying-to-openshift-native-howto"
 msgstr "deploying-to-openshift-native-howto"
 
 #. type: Hash Value: types howto summary
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "This guide describes how to deploy a Quarkus application to OpenShift compiled to native executables."
 msgstr "このガイドでは、ネイティブ実行可能ファイルにコンパイルされた Quarkus アプリケーションを OpenShift にデプロイする方法について説明します。"
 
 #. type: Hash Value: types howto title
-#. mt: gemini
 #: _data/versioned/latest/index/quarkus.yaml:1
 #, no-wrap
 msgid "Deploying Quarkus applications compiled to native executables"

--- a/l10n/po/ja_JP/_includes/CF-footerband.html.po
+++ b/l10n/po/ja_JP/_includes/CF-footerband.html.po
@@ -1,0 +1,25 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Content of: <div><div><div><a>
+#: _includes/CF-footerband.html:4
+msgid "<a class=\"cf-logo\" href=\"https://www.commonhaus.org/\" target=\"_blank\">"
+msgstr ""
+
+#. type: Content of: <div><div><div>
+#: _includes/CF-footerband.html:4
+msgid "</a>"
+msgstr ""
+
+#. type: Content of: <div><div><div>
+#: _includes/CF-footerband.html:7
+msgid "Copyright © Quarkus. All rights reserved. For details on our trademarks, please visit our <a href=\"https://www.commonhaus.org/policies/trademark-policy/\">Trademark Policy</a> and <a href=\"https://www.commonhaus.org/trademarks/\">Trademark List</a>. Trademarks of third parties are owned by their respective holders and their mention here does not suggest any endorsement or association."
+msgstr ""

--- a/l10n/po/ja_JP/_includes/ai-blueprints.html.po
+++ b/l10n/po/ja_JP/_includes/ai-blueprints.html.po
@@ -1,0 +1,80 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Attribute 'alt' of: <div><div><div><img><img>
+#: _includes/ai-blueprints.html:4 _includes/ai-blueprints.html:5
+msgid "AI blueprints icon"
+msgstr ""
+
+#. type: Content of: <div><div><div><h2>
+#: _includes/ai-blueprints.html:8
+msgid "Enterprise AI Blueprints for Java with Quarkus & LangChain4j"
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-blueprints.html:9
+msgid "The following three blueprints are conceptual, infrastructure-agnostic reference architectures. Each stands on its own and shows how to structure a Java solution with Quarkus (runtime, APIs, orchestration) and LangChain4j (LLM access, embeddings, tools, chains)."
+msgstr ""
+
+#. type: Content of: <div><div><div><p><p><p>
+#: _includes/ai-blueprints.html:10
+msgid "Quarkus provides the foundation for building secure, cloud-native, and AI-infused applications. Quarkus applications integrate with external model runtimes through LangChain4j, which offers rich abstractions for connecting to LLM providers, managing embeddings, defining tools, and orchestrating agentic workflows. This keeps AI where it belongs, as a capability embedded in enterprise applications, while Quarkus ensures performance, scalability, and operational reliability."
+msgstr ""
+
+#. type: Content of: <div><div><div><p><p><p><p><p>
+#: _includes/ai-blueprints.html:11
+msgid "These blueprints demonstrate practical patterns and best practices for developing enterprise-grade AI solutions using a combination of these technologies. They aim to simplify the process of using AI in Java applications and guiding software architects along the way. Whether you're building intelligent chatbots, recommendation engines, or sophisticated data analysis tools, these blueprints provide a solid starting point for your next AI project. Explore each blueprint to discover how Quarkus and LangChain4j can enrich your Java applications with advanced AI capabilities."
+msgstr ""
+
+#. type: Content of: <div><div><div><h3>
+#: _includes/ai-blueprints.html:15
+msgid "Frozen RAG (Retrieval-Augmented Generation)"
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-blueprints.html:16
+msgid "Improve LLM accuracy with RAG, leveraging enterprise data. Quarkus handles RAG's entire process, including data ingestion, query execution, embedding, context retrieval, and LLM communication."
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-blueprints.html:17
+msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/ai-frozen-rag\">Learn the basics of Frozen RAG</a>"
+msgstr ""
+
+#. type: Content of: <div><div><div><h3>
+#: _includes/ai-blueprints.html:21
+msgid "Contextual RAG (Multi-Sources, Rerank, Injection)"
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-blueprints.html:22
+msgid "Advanced Contextual RAG improves frozen RAG by adding multi-source retrieval, reranking, and content injection. This makes it ideal for complex enterprise scenarios, ensuring accuracy, relevance, and explainability across distributed information. It enables dynamic information handling, complex queries, and clear lineage for auditable, high-stakes decisions."
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-blueprints.html:23
+msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/ai-contextual-rag\">Learn about Contextual RAG </a>"
+msgstr ""
+
+#. type: Content of: <div><div><div><h3>
+#: _includes/ai-blueprints.html:27
+msgid "Chain-of-Thought (CoT) Reasoning"
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-blueprints.html:28
+msgid "Chain-of-Thought (CoT) guides LLMs through explicit intermediate steps to solve complex problems. This systematic approach breaks tasks into manageable sub-problems for sequential processing and solution building. CoT enhances LLM accuracy, enabling understanding and debugging, especially for multi-step reasoning in mathematical problem-solving, code generation, and logical inference."
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-blueprints.html:29
+msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/ai-chain-of-thought\">Learn about Chain-of-Thought Reasoning</a>"
+msgstr ""

--- a/l10n/po/ja_JP/_includes/ai-chainofthought.html.po
+++ b/l10n/po/ja_JP/_includes/ai-chainofthought.html.po
@@ -1,0 +1,155 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Content of: <div><div><div><h1>
+#: _includes/ai-chainofthought.html:4
+msgid "Chain-of-Thought (CoT) Reasoning"
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-chainofthought.html:5
+msgid "The architecture of the Chain-of-Thought (CoT) blueprint focuses on guiding a Large Language Model (LLM) through explicit intermediate steps to solve complex problems, improve reasoning, and provide transparency in its decision-making."
+msgstr ""
+
+#. type: Content of: <div><div><div><h2>
+#: _includes/ai-chainofthought.html:6
+msgid "Main Use-Cases"
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-chainofthought.html:8
+msgid "<strong>Improved Reasoning:</strong> Decompose complex problems to reduce logical errors."
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-chainofthought.html:9
+msgid "<strong>Transparency:</strong> Provide optional explanations for decisions."
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-chainofthought.html:10
+msgid "<strong>Training & Enablement:</strong> Illustrate the \"why\" behind concepts, not just the \"what.\""
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-chainofthought.html:11
+msgid "<strong>Decision Support:</strong> Aid in investments, vendor selection, and risk assessments."
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-chainofthought.html:12
+msgid "<strong>Troubleshooting:</strong> Facilitate structured diagnostics in operations and engineering."
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-chainofthought.html:13
+msgid "<strong>Policy Application:</strong> Apply multi-clause rules with traceable steps."
+msgstr ""
+
+#. type: Content of: <div><div><div><h2>
+#: _includes/ai-chainofthought.html:15
+msgid "Architecture Overview"
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-chainofthought.html:16
+msgid "The CoT architecture starts with a \"User Query\" that initiates the process. This query is received by the \"Quarkus CoT Service,\" which serves as the orchestrator for the entire reasoning flow. Within the Quarkus service, the core Chain-of-Thought logic, powered by LangChain4j, is executed."
+msgstr ""
+
+#. type: Attribute 'alt' of: <div><div><div><img><img>
+#: _includes/ai-chainofthought.html:17 _includes/ai-chainofthought.html:18
+msgid "CoT architecture image"
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><p>
+#: _includes/ai-chainofthought.html:19
+msgid "The \"LangChain4j\" package encapsulates the sequential steps of the CoT process:"
+msgstr ""
+
+#. type: Content of: <div><div><div><dl><dt>
+#: _includes/ai-chainofthought.html:23
+msgid "Step 1: Analyze Factors:"
+msgstr ""
+
+#. type: Content of: <div><div><div><dl><dd>
+#: _includes/ai-chainofthought.html:24
+msgid "This initial step involves the LLM breaking down the complex user query into its constituent parts, identifying key factors, and performing an initial analysis. This could involve understanding the problem, identifying relevant data points, or defining the scope of the task."
+msgstr ""
+
+#. type: Content of: <div><div><div><dl><dt>
+#: _includes/ai-chainofthought.html:29
+msgid "Step 2: Synthesize Options:"
+msgstr ""
+
+#. type: Content of: <div><div><div><dl><dd>
+#: _includes/ai-chainofthought.html:30
+msgid "Building on the analysis from Step 1, the LLM then synthesizes various options, potential solutions, or different perspectives related to the query. This step demonstrates the model's ability to explore different avenues of thought before arriving at a conclusion."
+msgstr ""
+
+#. type: Content of: <div><div><div><dl><dt>
+#: _includes/ai-chainofthought.html:35
+msgid "Step 3: Recommendation:"
+msgstr ""
+
+#. type: Content of: <div><div><div><dl><dd>
+#: _includes/ai-chainofthought.html:36
+msgid "In the final step, the LLM formulates a \"Recommendation\" or a definitive answer based on the analysis and synthesis performed in the preceding steps. This recommendation is the ultimate output of the CoT process."
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-chainofthought.html:40
+msgid "Finally, the Response is returned to the user, with the option to include the intermediate reasoning steps when transparency is required. Quarkus orchestrates the execution of single- or multi-prompt chains, while LangChain4j supplies the abstractions for building prompts and capturing reasoning outputs at each step. This structured flow improves the LLM’s performance on complex tasks and, when needed, provides an auditable record of how the answer was derived."
+msgstr ""
+
+#. type: Content of: <div><div><div><h2>
+#: _includes/ai-chainofthought.html:41
+msgid "Further Patterns"
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-chainofthought.html:42
+msgid "Further patterns in Chain-of-Thought reasoning extend beyond basic single-prompt approaches to offer more sophisticated control and integration. \"Single-prompt CoT\" provides a concise way to elicit reasoning, where a single instruction like \"think step by step\" guides the LLM to return both its thought process and the final answer."
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-chainofthought.html:43
+msgid "More advanced scenarios benefit from \"Program-of-Thought,\" which involves multiple chained prompts, where the output of one step feeds into the next, often including optional verification steps for enhanced accuracy."
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-chainofthought.html:44
+msgid "Lastly, a \"Hybrid\" approach combines CoT with Retrieval-Augmented Generation (RAG) to ground the reasoning process in factual information, ensuring that the LLM's logical steps are supported by relevant data. These patterns provide flexibility in how CoT is applied, allowing architects to choose the level of control and factual grounding necessary for their specific enterprise AI applications."
+msgstr ""
+
+#. type: Content of: <div><div><div><h2>
+#: _includes/ai-chainofthought.html:45
+msgid "Guardrails & Privacy"
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-chainofthought.html:46
+msgid "Architecting Chain-of-Thought (CoT) solutions for enterprise environments necessitates careful consideration of guardrails and privacy. The following points represent an initial excerpt of critical aspects that software architects must account for to ensure responsible and secure AI deployment. These considerations are vital to manage the transparency of reasoning, maintain answer consistency, and control data exposure within the CoT process."
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-chainofthought.html:48
+msgid "<strong>Reasoning Exposure:</strong> Decide whether to reveal the Chain of Thought (CoT) or keep it internal."
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-chainofthought.html:49
+msgid "<strong>Consistency Checks:</strong> Implement a final verifier prompt or apply deterministic post-rules."
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-chainofthought.html:50
+msgid "<strong>Token Budgeting:</strong> Limit intermediate verbosity and summarize between steps."
+msgstr ""

--- a/l10n/po/ja_JP/_includes/ai-contextualrag.html.po
+++ b/l10n/po/ja_JP/_includes/ai-contextualrag.html.po
@@ -1,0 +1,160 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Content of: <div><div><div><h1>
+#: _includes/ai-contextualrag.html:4
+msgid "Contextual RAG (Multi-Sources, Rerank, Injection)"
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-contextualrag.html:5
+msgid "Advanced Contextual RAG extends the core frozen RAG pattern by incorporating multi-source retrieval, reranking, and content injection techniques. This is designed for more complex enterprise scenarios where information might be spread across various systems, requiring more sophisticated methods to ensure accuracy, relevance, and explainability. It allows for dynamic information handling, complex query processing, and provides clearer lineage for auditable decisions, making it ideal for high-stakes applications."
+msgstr ""
+
+#. type: Content of: <div><div><div><h2>
+#: _includes/ai-contextualrag.html:6
+msgid "Main Use-Cases"
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-contextualrag.html:8
+msgid "<strong>Complex Queries:</strong> Addresses intricate questions requiring synthesis from multiple sources."
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-contextualrag.html:9
+msgid "<strong>Dynamic Information:</strong> Handles rapidly changing data environments by incorporating real-time updates."
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-contextualrag.html:10
+msgid "<strong>High-Accuracy Needs:</strong> Reranking and injection ensure more precise and relevant answers."
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-contextualrag.html:11
+msgid "<strong>Auditable Decisions:</strong> Provides clear lineage and context for generated responses, crucial for compliance and debugging."
+msgstr ""
+
+#. type: Content of: <div><div><div><h2>
+#: _includes/ai-contextualrag.html:13
+msgid "Architecture Overview"
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-contextualrag.html:14
+msgid "The process begins with a User Query, which is first processed by a Query Transformer to refine or enhance it for more effective retrieval. The transformed query is then passed to a Query Router that decides which knowledge sources to target. For unstructured data, the ingestion pipeline remains the same as in the foundational RAG architecture (documents split, embedded, and stored in a vector store), but contextual RAG extends retrieval to multiple sources such as structured databases, APIs, and search indexes."
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-contextualrag.html:15
+msgid "The <strong>Query Router</strong> is responsible for directing the query to multiple retrieval sources simultaneously. These sources include:"
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-contextualrag.html:17
+msgid "<strong>Vector Retriever:</strong> Retrieves information based on semantic similarity from a vector store."
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-contextualrag.html:18
+msgid "<strong>Web/Search Retriever:</strong> Gathers information from the web or external search engines."
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-contextualrag.html:19
+msgid "<strong>Database Retriever:</strong> Extracts relevant data from structured databases."
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-contextualrag.html:20
+msgid "<strong>Full-Text Retriever:</strong> Performs keyword-based searches across a corpus of documents."
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-contextualrag.html:22
+msgid "All the information retrieved from these diverse sources is then fed into an <strong>Aggregator/Reranker</strong>. This component combines and prioritizes the retrieved content based on relevance to the original query."
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-contextualrag.html:23
+msgid "The aggregated and reranked content is passed to a <strong>Content Injector (Prompt Builder)</strong>. This component constructs an Enhanced Prompt for the Large Language Model (LLM) by incorporating the retrieved context alongside the original user query."
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-contextualrag.html:24
+msgid "Finally, the LLM processes the <strong>Augmented Prompt</strong>, using the provided context to generate an answer. Alongside the answer, the system can return the retrieved source segments for transparency and verification, though these should be considered supporting context rather than strict citations."
+msgstr ""
+
+#. type: Attribute 'alt' of: <div><div><div><img><img>
+#: _includes/ai-contextualrag.html:25 _includes/ai-contextualrag.html:26
+msgid "Contextual RAG query image"
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><h2>
+#: _includes/ai-contextualrag.html:27
+msgid "Scalability & Performance"
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><p>
+#: _includes/ai-contextualrag.html:28
+msgid "Efficiently scaling and optimizing the performance of your AI solutions are crucial for enterprise adoption and operational success. While this blueprint only gives you some high level guidance, we strongly recommend to also look into the non functional aspects of your solution and ways to address these concepts:"
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><ul><li>
+#: _includes/ai-contextualrag.html:30
+msgid "<strong>Domain/Tenant Sharding:</strong> Retrieves information based on semantic similarity from a vector store."
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><ul><li>
+#: _includes/ai-contextualrag.html:31
+msgid "<strong>Caching:</strong> Cache query vectors and top-K hits for improved performance."
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><ul><li>
+#: _includes/ai-contextualrag.html:32
+msgid "<strong>Asynchronous Ingestion:</strong> Utilize asynchronous ingestion to batch embeddings and stream deltas."
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><ul><li>
+#: _includes/ai-contextualrag.html:33
+msgid "<strong>Lean Prompts:</strong> Prioritize token budget for context, keeping prompts concise."
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><h2>
+#: _includes/ai-contextualrag.html:35
+msgid "Security"
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><p>
+#: _includes/ai-contextualrag.html:36
+msgid "Architecting secure enterprise AI solutions demands a proactive approach to safeguard sensitive data and preserve organizational integrity. Below are some first thoughts about critical security considerations and architectural patterns you should further investigate when building your solution."
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><ul><li>
+#: _includes/ai-contextualrag.html:38
+msgid "<strong>Authorization at retrieval:</strong> Before injecting context, filter by user/tenant claims."
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><ul><li>
+#: _includes/ai-contextualrag.html:39
+msgid "<strong>Audit lineage:</strong> Store the chunk→document→source linkage with timestamps."
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><ul><li>
+#: _includes/ai-contextualrag.html:40
+msgid "<strong>PII controls:</strong> Redact or mask sensitive spans before embedding and prompting."
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><ul><li>
+#: _includes/ai-contextualrag.html:41
+msgid "<strong>Guard responses:</strong> Post-filter for data leakage and policy violations."
+msgstr ""

--- a/l10n/po/ja_JP/_includes/ai-frozenrag.html.po
+++ b/l10n/po/ja_JP/_includes/ai-frozenrag.html.po
@@ -1,0 +1,135 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Content of: <div><div><div><h1>
+#: _includes/ai-frozenrag.html:5
+msgid "Frozen RAG (Retrieval-Augmented Generation)"
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-frozenrag.html:6
+msgid "Integrate RAG to anchor Large Language Model (LLM) responses in your enterprise data, with Quarkus handling ingestion pipelines, query execution, embedding generation, context retrieval, and seamless LLM interaction. This blueprint focuses on the foundational RAG pattern (also called frozen RAG); more advanced contextual RAG variants, including multi-source routing and reranking, are covered separately."
+msgstr ""
+
+#. type: Content of: <div><div><div><h2>
+#: _includes/ai-frozenrag.html:7
+msgid "Main Use-Cases"
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-frozenrag.html:9
+msgid "<strong>Reduced Hallucinations:</strong> RAG ensures that LLM answers are explicitly tied to enterprise-specific sources such as policies, manuals, or knowledge bases. This grounding reduces the risk of fabricated or misleading responses and increases trust in AI-assisted decision-making."
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-frozenrag.html:10
+msgid "<strong>Up-to-Date Information:</strong> Because the retrieval step pulls directly from current document repositories and databases, responses adapt automatically as content evolves. There is no need to retrain or fine-tune the underlying model whenever business data changes."
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-frozenrag.html:11
+msgid "<strong>Cost Efficiency:</strong> By retrieving only the most relevant context chunks, prompts stay concise. This reduces token usage in LLM calls, which directly lowers cost while preserving accuracy and completeness."
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-frozenrag.html:12
+msgid "<strong>Java-Native Enterprise Integration:</strong> Quarkus provides a first-class runtime for embedding RAG workflows into existing enterprise systems. Developers can secure RAG services with OIDC or LDAP, expose them through familiar REST or Kafka APIs, and monitor them with Prometheus and OpenTelemetry. Because RAG runs inside the same application fabric as other Java services, it fits naturally into existing authentication, authorization, deployment, and observability workflows. This ensures AI augmentation is not just added, but part of the enterprise architecture."
+msgstr ""
+
+#. type: Content of: <div><div><div><h2>
+#: _includes/ai-frozenrag.html:14
+msgid "Architecture Overview"
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-frozenrag.html:15
+msgid "Contextual RAG focuses on integrating Retrieval-Augmented Generation (RAG) to ground Large Language Model (LLM) responses in organizational data."
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-frozenrag.html:16
+msgid "The architecture is divided into two main phases:"
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-frozenrag.html:17
+msgid "<strong>Ingestion:</strong> This phase prepares enterprise knowledge for retrieval. In a frozen RAG setup, data typically originates from unstructured document sources such as manuals, PDFs, or reports."
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-frozenrag.html:19
+msgid "Documents are processed by a \"Text Splitter\" to break them into smaller chunks."
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-frozenrag.html:20
+msgid "These chunks are then converted into numerical representations (embeddings) using an \"Embedding Model\"."
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-frozenrag.html:21
+msgid "The embeddings are stored in a \"Vector Store\" for semantic similarity searches."
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-frozenrag.html:22
+msgid "Metadata about the documents, such as lineage and other relevant information, is stored in a \"Metadata Store\"."
+msgstr ""
+
+#. type: Attribute 'alt' of: <div><div><div><img><img>
+#: _includes/ai-frozenrag.html:24 _includes/ai-frozenrag.html:25
+msgid "Frozen RAG ingestion image"
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><p>
+#: _includes/ai-frozenrag.html:26
+msgid "<strong>Query:</strong> This phase handles user queries and generates grounded answers."
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><ul><li>
+#: _includes/ai-frozenrag.html:28
+msgid "A \"User Query\" is received and processed by a \"Query Embedding\" component to create an embedding of the query."
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><ul><li>
+#: _includes/ai-frozenrag.html:29
+msgid "The query embedding is used in a \"Similarity Search\" against the \"Vector Store\" to retrieve relevant document chunks. The \"Vector Store\" \"serves\" the similarity search."
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><ul><li>
+#: _includes/ai-frozenrag.html:30
+msgid "The retrieved chunks, along with metadata from the \"Metadata Store\" (which acts as the \"source of truth\"), are assembled into a \"Context Pack\"."
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><ul><li>
+#: _includes/ai-frozenrag.html:31
+msgid "The \"Context Pack\" is used by a \"Prompt Assembly\" component to construct an \"Enhanced Prompt\" that includes the relevant context."
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><ul><li>
+#: _includes/ai-frozenrag.html:32
+msgid "The \"Enhanced Prompt\" is fed into an \"LLM (LangChain4j)\"."
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><ul><li>
+#: _includes/ai-frozenrag.html:33
+msgid "The LLM generates a \"Grounded Answer\" based on the provided context."
+msgstr ""
+
+#. type: Attribute 'alt' of: <div><div><div><img><img><img><img>
+#: _includes/ai-frozenrag.html:35 _includes/ai-frozenrag.html:36
+msgid "Frozen RAG query image"
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><img><img><p>
+#: _includes/ai-frozenrag.html:37
+msgid "This two-phase approach allows for reduced hallucinations in LLM responses, up-to-date information without retraining, cost efficiency by retrieving only relevant information, and seamless integration with existing enterprise Java services and workflows."
+msgstr ""

--- a/l10n/po/ja_JP/_includes/ai-java-for-ai.html.po
+++ b/l10n/po/ja_JP/_includes/ai-java-for-ai.html.po
@@ -1,0 +1,200 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Attribute 'alt' of: <div><div><div><img>
+#: _includes/ai-java-for-ai.html:4
+msgid "Java for AI icon"
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-java-for-ai.html:7
+msgid "Artificial Intelligence is reshaping enterprise software, and Java remains the backbone. Its long-standing reliability, security, and scalability make it ideal for building AI-infused applications."
+msgstr ""
+
+#. type: Content of: <div><div><div><h2>
+#: _includes/ai-java-for-ai.html:11
+msgid "Java in Data Preparation"
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-java-for-ai.html:12
+msgid "Many AI initiatives begin with robust data processing pipelines."
+msgstr ""
+
+#. type: Content of: <div><div><div><h3>
+#: _includes/ai-java-for-ai.html:13
+msgid "Effective AI requires two distinct pipelines:"
+msgstr ""
+
+#. type: Content of: <div><div><div><dl><dt>
+#: _includes/ai-java-for-ai.html:17
+msgid "Training Data Preparation"
+msgstr ""
+
+#. type: Content of: <div><div><div><dl><dd>
+#: _includes/ai-java-for-ai.html:18
+msgid "Build predictive models with DeepLearning4J (DL4J). Java’s ecosystem, including Apache Kafka, Apache Flink, and Apache Camel, supports large-scale ETL, data cleansing, and preprocessing across enterprise data."
+msgstr ""
+
+#. type: Content of: <div><div><div><dl><dt>
+#: _includes/ai-java-for-ai.html:23
+msgid "RAG Data Preparation"
+msgstr ""
+
+#. type: Content of: <div><div><div><dl><dd>
+#: _includes/ai-java-for-ai.html:24
+msgid "For Retrieval-Augmented Generation, ingest documents and business knowledge, compute embeddings, and index in vector stores. Java seamlessly connects to databases, message brokers, and vector stores, enabling RAG pipelines that are both fast and reliable."
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-java-for-ai.html:28
+msgid "This dual capability, supporting both model training and RAG processes, makes Java uniquely powerful in AI architectures."
+msgstr ""
+
+#. type: Content of: <div><div><div><h2>
+#: _includes/ai-java-for-ai.html:34
+msgid "Java for AI-Infused Applications and Intelligent Applications"
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-java-for-ai.html:35
+msgid "Once data and models are ready, enterprises need applications that:"
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-java-for-ai.html:37
+msgid "Embed AI in customer-facing workflows (chatbots, fraud detection, document assistants)."
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-java-for-ai.html:38
+msgid "Interact with predictive and generative AI models (in-process, locally or remotely)."
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-java-for-ai.html:39
+msgid "Scale from prototype to production on cloud or on-prem."
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-java-for-ai.html:41
+msgid "The JVM ecosystem ensures consistency, portability, and performance across deployments."
+msgstr ""
+
+#. type: Content of: <div><div><div><h2>
+#: _includes/ai-java-for-ai.html:45
+msgid "Enterprise-Grade Security, Governance & Observability"
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-java-for-ai.html:46
+msgid "Java brings full enterprise readiness to AI systems:"
+msgstr ""
+
+#. type: Content of: <div><div><div><dl><dt>
+#: _includes/ai-java-for-ai.html:50
+msgid "Security by Design:"
+msgstr ""
+
+#. type: Content of: <div><div><div><dl><dd>
+#: _includes/ai-java-for-ai.html:51
+msgid "Supports traceable inputs, audit trails, and governance-ready execution from day one."
+msgstr ""
+
+#. type: Content of: <div><div><div><dl><dt>
+#: _includes/ai-java-for-ai.html:56
+msgid "Proven at Scale:"
+msgstr ""
+
+#. type: Content of: <div><div><div><dl><dd>
+#: _includes/ai-java-for-ai.html:57
+msgid "Decades of enterprise deployment ensure predictable performance and long-term maintainability."
+msgstr ""
+
+#. type: Content of: <div><div><div><dl><dt>
+#: _includes/ai-java-for-ai.html:62
+msgid "Stable Innovation:"
+msgstr ""
+
+#. type: Content of: <div><div><div><dl><dd>
+#: _includes/ai-java-for-ai.html:63
+msgid "Embraces modern tools like LangChain4j while preserving strong typing, backward compatibility, and developer familiarity."
+msgstr ""
+
+#. type: Content of: <div><div><div><dl><dt>
+#: _includes/ai-java-for-ai.html:68
+msgid "Observability:"
+msgstr ""
+
+#. type: Content of: <div><div><div><dl><dd>
+#: _includes/ai-java-for-ai.html:69
+msgid "Java applications, especially those built with Quarkus, incorporate metrics, tracing, and logs, thereby improving operational tasks. This unified telemetry enables real-time monitoring of AI pipelines and live troubleshooting."
+msgstr ""
+
+#. type: Content of: <div><div><div><h2>
+#: _includes/ai-java-for-ai.html:74
+msgid "Java & Emerging AI Protocols"
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-java-for-ai.html:75
+msgid "The Java ecosystem has long been foundational for interoperability."
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-java-for-ai.html:76
+msgid "So, it’s not surprising to see Java client and server implementations for the emerging AI protocols, such as:"
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-java-for-ai.html:78
+msgid "<strong>MCP (Model context Protocol):</strong> Enables building servers and clients that integrate LLMs with enterprise systems."
+msgstr ""
+
+#. type: Content of: <div><div><div><ul><li>
+#: _includes/ai-java-for-ai.html:79
+msgid "<strong>A2A (Agent-to-Agent):</strong> Supports reliable autonomous agent communication across ecosystems."
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-java-for-ai.html:81
+msgid "Java’s mature networking and concurrency capabilities make it ideal for implementing these agentic, AI-driven architectures."
+msgstr ""
+
+#. type: Content of: <div><div><div><h2>
+#: _includes/ai-java-for-ai.html:85
+msgid "Dive into using Java and AI"
+msgstr ""
+
+#. type: Content of: <div><div><div><div><div><p>
+#: _includes/ai-java-for-ai.html:88
+msgid "For Java enterprise developers and architects looking to expand their skill set into artificial intelligence and machine learning (AI/ML), getting started can feel intimidating, especially when faced with complex theory, data science, and unfamiliar programming languages."
+msgstr ""
+
+#. type: Content of: <div><div><div><div><div><p>
+#: _includes/ai-java-for-ai.html:89
+msgid "Check out \"Applied AI for Enterprise Java Development\" by Alex Soto Bueno, Markus Eisele, and Natale Vinto. It's a practical guide which shows you how to integrate generative AI, large language models, and machine learning into your existing Java enterprise ecosystem, using tools and frameworks you already know and love."
+msgstr ""
+
+#. type: Content of: <div><div><div><div><div><p>
+#: _includes/ai-java-for-ai.html:90
+msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"https://developers.redhat.com/e-books/applied-ai-enterprise-java-development\">Download the free ebook now!</a>"
+msgstr ""
+
+#. type: Content of: <div><div><div><div><div><a>
+#: _includes/ai-java-for-ai.html:93
+msgid "<a href=\"https://developers.redhat.com/e-books/applied-ai-enterprise-java-development\" alt=\"Applied AI for Enterprise Java Development link\">"
+msgstr ""
+
+#. type: Attribute 'alt' of: <div><div><div><div><div><a><img>
+#: _includes/ai-java-for-ai.html:93
+msgid "Applied AI for Enterprise Java Development image"
+msgstr ""

--- a/l10n/po/ja_JP/_includes/ai-overview.html.po
+++ b/l10n/po/ja_JP/_includes/ai-overview.html.po
@@ -1,0 +1,130 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Attribute 'alt' of: <div><div><div><img>
+#: _includes/ai-overview.html:4
+msgid "Java for AI icon"
+msgstr ""
+
+#. type: Content of: <div><div><div><h2>
+#: _includes/ai-overview.html:7
+msgid "Why use Java for AI?"
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-overview.html:8
+msgid "Java is ideal for AI development due to its platform independence, robust memory management, and rich open-source libraries like Deeplearning4j, Weka, and Apache Spark. Its mature ecosystem and strong community support enable scalable AI applications. With recent JVM optimizations, Java's performance handles demanding machine learning tasks and large datasets efficiently."
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-overview.html:9
+msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/java-for-ai\">Learn more about using Java for AI</a>"
+msgstr ""
+
+#. type: Content of: <div><div><div><h2>
+#: _includes/ai-overview.html:13
+msgid "Why use Quarkus for AI-Infused Applications"
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-overview.html:14
+msgid "Quarkus is ideal for AI applications due to its performance, agility, and developer experience. It offers native Generative AI integration via LangChain4j, supporting declarative AI services, various LLMs, and advanced prompt engineering. It also handles predictive AI and data pipeline automation with ML toolkits for scalable ETL and embedding workflows. Quarkus's \"AI-Enhanced Developer Experience\" provides fast startups, low memory, and a reactive core for cloud-native AI. It boosts developer velocity with live coding, a unified Java stack, and robust observability/security for reliable AI services."
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-overview.html:15
+msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/quarkus-for-ai\">Learn more about using Quarkus for AI</a>"
+msgstr ""
+
+#. type: Content of: <div><div><div><h3>
+#: _includes/ai-overview.html:19
+msgid "Benefits of Quarkus for AI-Infused Applications"
+msgstr ""
+
+#. type: Attribute 'alt' of: <div><div><div><img><img>
+#: _includes/ai-overview.html:22 _includes/ai-overview.html:23
+msgid "Native Integration with Generative AI icon"
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><h4>
+#: _includes/ai-overview.html:24
+msgid "Native Integration with Generative AI"
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><p>
+#: _includes/ai-overview.html:25
+msgid "Easily build AI workflows with minimal code, leveraging top LLM providers to create features like chatbots and summarizers."
+msgstr ""
+
+#. type: Attribute 'alt' of: <div><div><div><img><img>
+#: _includes/ai-overview.html:28 _includes/ai-overview.html:29
+msgid "Predictive AI and Data Pipelines icon"
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><h4>
+#: _includes/ai-overview.html:30
+msgid "Predictive AI and Data Pipelines"
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><p>
+#: _includes/ai-overview.html:31
+msgid "Enable predictive AI, model training, and scalable data workflows, connecting seamlessly to ML tools, message brokers, databases, and files."
+msgstr ""
+
+#. type: Attribute 'alt' of: <div><div><div><img><img>
+#: _includes/ai-overview.html:34 _includes/ai-overview.html:35
+msgid "Enhanced Developer Experience icon"
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><h4>
+#: _includes/ai-overview.html:36
+msgid "Enhanced Developer Experience"
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><p>
+#: _includes/ai-overview.html:37
+msgid "Incorporate AI directly into development workflow with instant feedback, code explanations, and documentation, speeding up iterations."
+msgstr ""
+
+#. type: Attribute 'alt' of: <div><div><div><img><img>
+#: _includes/ai-overview.html:40 _includes/ai-overview.html:41
+msgid "Enterprise-Grade icon"
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><h4>
+#: _includes/ai-overview.html:42
+msgid "Enterprise-Grade AI"
+msgstr ""
+
+#. type: Content of: <div><div><div><img><img><p>
+#: _includes/ai-overview.html:43
+msgid "Create reliable, secure AI applications using Quarkus’s built-in observability, security, and governance—ensuring AI services are safe, accountable, and performance-ready from the beginning."
+msgstr ""
+
+#. type: Attribute 'alt' of: <div><div><div><img><img>
+#: _includes/ai-overview.html:49 _includes/ai-overview.html:50
+msgid "AI blueprints icon"
+msgstr ""
+
+#. type: Content of: <div><div><div><h2>
+#: _includes/ai-overview.html:53
+msgid "Enterprise AI Blueprints for Java with Quarkus & LangChain4j"
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-overview.html:54
+msgid "AI blueprints offer conceptual, infrastructure-agnostic reference architectures for developing enterprise-grade AI solutions in Java. They simplify AI integration in Java applications, guiding software architects in building intelligent chatbots, recommendation engines, and data analysis tools. These blueprints, leveraging Quarkus and LangChain4j, provide a solid starting point for advanced AI capabilities in your Java projects."
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/ai-overview.html:55
+msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/ai-blueprints\">Learn more about using Quarkus for AI</a>"
+msgstr ""

--- a/l10n/po/ja_JP/_includes/developer-joy.html.po
+++ b/l10n/po/ja_JP/_includes/developer-joy.html.po
@@ -22,7 +22,6 @@ msgid "Improve and expedite the inner loop development process with live coding 
 msgstr "コードの変更が実行中のアプリケーションに自動的に反映されるライブコーディングにより、インナーループの開発プロセスを改善し、迅速化します。 コード → ブラウザ更新 → 繰り返し"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/developer-joy.html:13
 msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/guides/maven-tooling#dev-mode\">Read the Dev Mode guide</a>"
 msgstr "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/guides/maven-tooling#dev-mode\">開発モードガイドを読む</a>"
@@ -58,7 +57,6 @@ msgid "Visualize and configure extensions as well as access to application logs 
 msgstr "エクステンションの可視化と設定だけでなく、アプリケーションログやテストコンポーネントへのアクセスが可能"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/developer-joy.html:26
 msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/guides/dev-ui\">Read the Dev UI guide</a>"
 msgstr "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/guides/dev-ui\">Dev UI ガイドを読む</a>"
@@ -74,7 +72,6 @@ msgid "Automatic provisioning and application wiring of supporting services such
 msgstr "データベース、IDサーバーなどのサポートサービスの自動プロビジョニングとアプリケーションの接続"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/developer-joy.html:31
 msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/guides/dev-services\">Read the Dev Services guide</a>"
 msgstr "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/guides/dev-services\">Dev Services ガイドを読む</a>"
@@ -90,7 +87,6 @@ msgid "Get instant feedback on code changes as tests run in the background on im
 msgstr "影響を受けたコードに対してテストがバックグラウンドで実行されるため、コードの変更に関するフィードバックを即座に得ることができます。"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/developer-joy.html:36
 msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/guides/continuous-testing\">Read the Continuous Testing guide</a>"
 msgstr "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/guides/continuous-testing\">継続的テストガイドを読む</a>"
@@ -106,7 +102,6 @@ msgid "Create projects, manage extensions, and execute essential build and dev c
 msgstr "プロジェクトを作成し、エクステンションを管理し、必要なビルドや開発コマンドを実行します。"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/developer-joy.html:41
 msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/guides/cli-tooling\">Read the CLI Tooling guide</a>"
 msgstr "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/guides/cli-tooling\">CLI ツールガイドを読む</a>"
@@ -122,7 +117,6 @@ msgid "Run <a href=\"{{site.baseurl}}/guides/maven-tooling#dev-mode\">dev mode</
 msgstr "<a href=\"{{site.baseurl}}/guides/maven-tooling#dev-mode\">開発モード</a>をリモートで実行し、ローカルファイルへの変更をコンテナ化環境ですぐ利用出来るようにします。"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/developer-joy.html:46
 msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/guides/maven-tooling#remote-development-mode\">Read the Remote Development Mode guide</a>"
 msgstr "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/guides/maven-tooling#remote-development-mode\">リモート開発モードガイドを読む</a>"

--- a/l10n/po/ja_JP/_includes/discussion.html.po
+++ b/l10n/po/ja_JP/_includes/discussion.html.po
@@ -7,7 +7,6 @@ msgstr ""
 "X-Generator: doc-l10n-kit\n"
 
 #. type: Content of: <div><div><div><H3>
-#. mt: gemini
 #: _includes/discussion.html:4
 msgid "Quarkus's Collaborative Community Forum"
 msgstr "Quarkus の共同コミュニティフォーラム"
@@ -18,7 +17,6 @@ msgid "The core foundation of every good open source project is open discussion 
 msgstr "すべての優れたオープンソースプロジェクトの中核となる基盤は、オープンな議論とコラボレーションです。Quarkusはこの信念を貫いています。コミュニティがオープンにコミュニケーションできるように、GitHub Discussionsを有効にしています。これにより、コミュニティがプロジェクトに関する質問をしたり、回答したりするための中心となる場所ができました。これは、すべての素晴らしい知識が共有され、発見できることを意味しています。さらに、Quarkusコミュニティに関するその他の会話もここで行うことができます。私たちと一緒にコラボレーションしましょう。"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/discussion.html:6
 msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"https://github.com/quarkusio/quarkus/discussions\">Go to the Quarkus GitHub Discussions<i class=\"fas fa-external-link-alt\"></i></a>"
 msgstr "<i class=\"fa fa-chevron-right\"></i><a href=\"https://github.com/quarkusio/quarkus/discussions\">Quarkus GitHub Discussions へ移動<i class=\"fas fa-external-link-alt\"></i></a>"
@@ -29,7 +27,6 @@ msgid "Quarkus Chat Options"
 msgstr "Quarkusのチャットオプション"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/discussion.html:10
 msgid "For usage questions, ask on <a href=\"https://stackoverflow.com/questions/tagged/quarkus\">Stack Overflow with the <code>quarkus</code> tag</a>."
 msgstr "使用方法に関する質問は、 <a href=\"https://stackoverflow.com/questions/tagged/quarkus\">`quarkus` タグを付けて Stack Overflow で質問してください</a>。"
@@ -40,7 +37,6 @@ msgid "For questions related to the development of Quarkus:"
 msgstr "Quarkusの開発に関する質問は、こちら:"
 
 #. type: Content of: <div><div><div><ul><li>
-#. mt: gemini
 #: _includes/discussion.html:13
 msgid "Use the <a href=\"https://groups.google.com/d/forum/quarkus-dev\" target=\"_blank\">quarkus-dev Google Groups</a>"
 msgstr "<a href=\"https://groups.google.com/d/forum/quarkus-dev\" target=\"_blank\">quarkus-dev Google Groups</a> を使用してください"

--- a/l10n/po/ja_JP/_includes/homepage-commonhaus-band.html.po
+++ b/l10n/po/ja_JP/_includes/homepage-commonhaus-band.html.po
@@ -1,0 +1,35 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Content of: <div><div><div><a>
+#: _includes/homepage-commonhaus-band.html:4
+msgid "<a href=\"https://www.commonhaus.org/\">"
+msgstr ""
+
+#. type: Attribute 'alt' of: <div><div><div><a><img><img>
+#: _includes/homepage-commonhaus-band.html:4
+msgid "Quarkus is part of the Commonhaus Foundation."
+msgstr ""
+
+#. type: Content of: <div><div><div><h2>
+#: _includes/homepage-commonhaus-band.html:7
+msgid "Quarkus is part of the Commonhaus Foundation"
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/homepage-commonhaus-band.html:8
+msgid "In order to fulfill our goal of being a more inclusive and fostering a more collaborative environment, we have moved to the Commonhaus Foundation. This is a step to further solidify our commitment to open-source development and enterprise adoption, addressing the perception that it was overly dependent on a single vendor (Red Hat). This move aims to provide a neutral ground where other organizations and contributors can feel equally valued and involved, ensuring Quarkus continues to thrive, supported by a broad base of contributors from multiple organizations."
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/homepage-commonhaus-band.html:9
+msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"https://www.commonhaus.org/\">Learn more about Commonhaus Foundation.</a>"
+msgstr ""

--- a/l10n/po/ja_JP/_includes/kubernetes-native.html.po
+++ b/l10n/po/ja_JP/_includes/kubernetes-native.html.po
@@ -7,145 +7,121 @@ msgstr ""
 "X-Generator: doc-l10n-kit\n"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/kubernetes-native.html:8
 msgid "The combination of Quarkus and Kubernetes provides an ideal environment for creating scalable, fast, and lightweight applications. Quarkus significantly increases developer productivity with tooling, pre-built integrations, application services, and more."
 msgstr "QuarkusとKubernetesの組み合わせは、スケーラブルで高速、かつ軽量なアプリケーションを作成するための理想的な環境を提供します。Quarkusは、ツール、事前に構築された統合、アプリケーションサービスなどにより、開発者の生産性を大幅に向上させます。"
 
 #. type: Content of: <div><div><div><h2>
-#. mt: gemini
 #: _includes/kubernetes-native.html:12
 msgid "What does it mean to be a Kubernetes-native framework?"
 msgstr "Kubernetesネイティブなフレームワークとはどういうことでしょうか？"
 
 #. type: Content of: <div><div><div><h3>
-#. mt: gemini
 #: _includes/kubernetes-native.html:15
 msgid "Single-step Deployments"
 msgstr "シングルステップのデプロイメント"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/kubernetes-native.html:16
 msgid "Quarkus makes it easy to deploy microservice applications to Kubernetes without having to understand the intricacies of the underlying Kubernetes framework. Extensions are available for Kubernetes, and Kubernetes distributions, to facilitate this process with only a minimal amount of configuration variables needed."
 msgstr "Quarkusでは、基盤となるKubernetesフレームワークの複雑な仕組みを理解することなく、マイクロサービスアプリケーションをKubernetesに簡単にデプロイできます。KubernetesやKubernetesのディストリビューションに対応したエクステンションが用意されており、必要最小限の設定変数のみでこのプロセスを促進することができます。"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/kubernetes-native.html:17
 msgid "Using the Quarkus Kubernetes extension, developers can perform or automate a single-step deployment using Jib, Docker, and Source-to-Image (S2i) including the creation of DeploymentConfig to trigger automatic redeployments."
 msgstr "Quarkus Kubernetesエクステンションを使用すると、開発者はJib、Docker、Source-to-Image (S2i) を使用してシングルステップのデプロイメントを実行または自動化できます。これには、自動再デプロイをトリガーするためのDeploymentConfigの作成も含まれます。"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/kubernetes-native.html:18 _includes/kubernetes-native.html:20
 msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/guides/deploying-to-kubernetes\">Read the \"Kubernetes extension\" guide</a>"
 msgstr "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/guides/deploying-to-kubernetes\">「Kubernetesエクステンション」ガイドを読む</a>"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/kubernetes-native.html:18
 msgid "&nbsp;"
 msgstr "&nbsp;"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/kubernetes-native.html:19
 msgid "Additionally, Quarkus includes extensions that make it easy to deploy serverless microservices to cloud providers including AWS Lambda, Azure Functions, and Google Cloud Functions as well as Knative to take advantage of Quarkus application’s fast startup times."
 msgstr "さらに、Quarkusには、サーバーレスマイクロサービスをAWS Lambda、Azure Functions、Google Cloud FunctionsなどのクラウドプロバイダーやKnativeに簡単にデプロイし、Quarkusアプリケーションの高速な起動時間を活用できるエクステンションが含まれています。"
 
 #. type: Content of: <div><div><div><h3>
-#. mt: gemini
 #: _includes/kubernetes-native.html:23
 msgid "Tracing & Debugging"
 msgstr "トレース & デバッグ"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/kubernetes-native.html:24
 msgid "Quarkus provides developers the tools and capabilities to troubleshoot distributed microservices applications in Kubernetes including tracing and debugging."
 msgstr "Quarkusは、トレースやデバッグなど、Kubernetes上の分散型マイクロサービスアプリケーションをトラブルシューティングするためのツールと機能を開発者に提供します。"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/kubernetes-native.html:25
 msgid "Quarkus utilizes <a href=\"https://opentelemetry.io/\" target=\"_blank\">OpenTelemetry</a> which is a vendor-agnostic API to help developers easily instrument tracing into their codebase. Distributed tracing helps pinpoint where failures occur and what causes poor performance."
 msgstr "Quarkusは、ベンダーに依存しないAPIである <a href=\"https://opentelemetry.io/\" target=\"_blank\">OpenTelemetry</a> を利用し、開発者がコードベースにトレースを簡単に組み込むのを支援します。分散トレースは、障害の発生箇所とパフォーマンス低下の原因を特定するのに役立ちます。"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/kubernetes-native.html:26
 msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/guides/opentelemetry\">Read the \"Using OpenTelemetry\" guide </a>"
 msgstr "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/guides/opentelemetry\">「OpenTelemetryの使用」ガイドを読む </a>"
 
 #. type: Content of: <div><div><div><h3>
-#. mt: gemini
 #: _includes/kubernetes-native.html:29
 msgid "Application Health"
 msgstr "アプリケーションヘルス"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/kubernetes-native.html:30
 msgid "Quarkus leverages SmallRye Health, an implementation of the MicroProfile Health specification. This allows applications to provide information about their state to external viewers in a Kubernetes environment where automated processes must be able to determine whether the application should be discarded or restarted."
 msgstr "Quarkusは、MicroProfile Health仕様の実装であるSmallRye Healthを活用しています。これにより、アプリケーションはKubernetes環境でその状態に関する情報を外部のビューアーに提供できます。Kubernetes環境では、自動化されたプロセスがアプリケーションを破棄すべきか再起動すべきかを判断できる必要があります。"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/kubernetes-native.html:31
 msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/guides/microprofile-health\">Read the \"Smallrye Health\" guide</a>"
 msgstr "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/guides/microprofile-health\">「SmallRye Health」ガイドを読む</a>"
 
 #. type: Content of: <div><div><div><h3>
-#. mt: gemini
 #: _includes/kubernetes-native.html:34
 msgid "Application Metrics"
 msgstr "アプリケーションメトリクス"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/kubernetes-native.html:35
 msgid "Quarkus utilizes the <a href=\"https://micrometer.io/\" target=\"_blank\">Micrometer</a> metrics library for runtime and application metrics. It provides a simple facade for the most popular monitoring systems to instrument your JVM-based application code without vendor lock-in. Application-specific and built-in metrics can be exposed using Micrometer."
 msgstr "Quarkusは、ランタイムおよびアプリケーションメトリクスに <a href=\"https://micrometer.io/\" target=\"_blank\">Micrometer</a> メトリクスライブラリを利用しています。これは、最も人気のある監視システムに対するシンプルなファサードを提供し、ベンダーロックインなしでJVMベースのアプリケーションコードを計装できます。アプリケーション固有のメトリクスや組み込みメトリクスは、Micrometerを使用して公開できます。"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/kubernetes-native.html:36
 msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/guides/micrometer#support-for-the-microprofile-metrics-api\">Read the \"Micrometer Metrics\" guide</a>"
 msgstr "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/guides/micrometer#support-for-the-microprofile-metrics-api\">「Micrometerメトリクス」ガイドを読む</a>"
 
 #. type: Content of: <div><div><div><h3>
-#. mt: gemini
 #: _includes/kubernetes-native.html:39
 msgid "Application Configuration"
 msgstr "アプリケーション設定"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/kubernetes-native.html:40
 msgid "Quarkus includes an extension that allows developers to use Kubernetes ConfigMaps and Secrets as a configuration source, without having to mount them into the Pod running the Quarkus application or make any other modifications to their Kubernetes Deployment (or Openshift DeploymentConfig)."
 msgstr "Quarkusには、Kubernetes ConfigMapsとSecretsを設定ソースとして使用できるエクステンションが含まれており、Quarkusアプリケーションを実行しているPodにそれらをマウントしたり、Kubernetes Deployment (またはOpenshift DeploymentConfig) に他の変更を加えたりする必要はありません。"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/kubernetes-native.html:41
 msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/guides/kubernetes-config\">Read the \"Kubernetes Config\" guide</a>"
 msgstr "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/guides/kubernetes-config\">「Kubernetes設定」ガイドを読む</a>"
 
 #. type: Content of: <div><div><div><h3>
-#. mt: gemini
 #: _includes/kubernetes-native.html:44
 msgid "Remote Development"
 msgstr "リモート開発"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/kubernetes-native.html:45
 msgid "Create and debug applications in the same environment where applications run. Live coding in development mode where any changes made locally will be immediately visible in a clustered Kubernetes environment."
 msgstr "アプリケーションが実行されるのと同じ環境で、アプリケーションを作成しデバッグします。開発モードでのライブコーディングでは、ローカルで行われた変更はクラスター化されたKubernetes環境に即座に反映されます。"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/kubernetes-native.html:46
 msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"https://developers.redhat.com/blog/2021/02/11/enhancing-the-development-loop-with-quarkus-remote-development\">Read the \"Enhancing the development loop with Quarkus remote development\" blog post </a>"
 msgstr "<i class=\"fa fa-chevron-right\"></i><a href=\"https://developers.redhat.com/blog/2021/02/11/enhancing-the-development-loop-with-quarkus-remote-development\">「Quarkusリモート開発による開発ループの強化」ブログ記事を読む </a>"

--- a/l10n/po/ja_JP/_includes/newsletter-band.html.po
+++ b/l10n/po/ja_JP/_includes/newsletter-band.html.po
@@ -1,0 +1,40 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Content of: <div><div><div><h3>
+#: _includes/newsletter-band.html:4
+msgid "{{ site.data.newsletter.headline }}"
+msgstr ""
+
+#. type: Content of: <div><div>
+#: _includes/newsletter-band.html:7
+msgid "{% for item in site.data.newsletter.newsletter %}"
+msgstr ""
+
+#. type: Content of: <div><div><div>
+#: _includes/newsletter-band.html:9
+msgid "<a href=\"{{ item.link }}\"></a>"
+msgstr ""
+
+#. type: Content of: <div><div><div><div><p>
+#: _includes/newsletter-band.html:11
+msgid "{{ item.title }}"
+msgstr ""
+
+#. type: Content of: <div><div><div><div><div>
+#: _includes/newsletter-band.html:12
+msgid "Publication Date: {{ item.date }}"
+msgstr ""
+
+#. type: Content of: <div><div>
+#: _includes/newsletter-band.html:15
+msgid "{% endfor %}"
+msgstr ""

--- a/l10n/po/ja_JP/_includes/performance.html.po
+++ b/l10n/po/ja_JP/_includes/performance.html.po
@@ -11,211 +11,176 @@ msgstr ""
 "X-Generator: Poedit 3.5\n"
 
 #. type: Attribute 'alt' of: <div><div><div><img><img>
-#. mt: gemini
 #: _includes/performance.html:4 _includes/performance.html:5
 msgid "Container image"
 msgstr "コンテナーイメージ"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/performance.html:8
 msgid "Quarkus is engineered to be efficient by using build-time optimizations and a reactive core to achieve fast startup times, high throughput, low response latency, reduced memory footprint, and minimal resource consumption. As a result, Quarkus is fast... real fast."
 msgstr "Quarkusは、ビルド時の最適化とリアクティブコアを使用することで効率的に設計されており、高速な起動時間、高いスループット、低い応答レイテンシー、削減されたメモリフットプリント、最小限のリソース消費を実現します。その結果、Quarkusは高速です...非常に高速です。"
 
 #. type: Content of: <div><div><div><h2>
-#. mt: gemini
 #: _includes/performance.html:11
 msgid "Starting fast by doing less: the build-time principle"
 msgstr "最小限の作業で高速起動: ビルド時原則"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/performance.html:14
 msgid "Quarkus redefines how Java applications are built and executed by shifting much of the work to the build phase ensuring that the costly work happens only once — during the build process — not at every startup. It results in faster, smaller, and more resource-efficient Java applications on both GraalVM native images and traditional JVM deployments."
 msgstr "Quarkusは、作業の大部分をビルドフェーズに移行させることで、Javaアプリケーションの構築と実行方法を再定義します。これにより、高コストの作業はビルドプロセス中に一度だけ発生し、起動のたびに繰り返されることはありません。その結果、GraalVMネイティブイメージと従来のJVMデプロイメントの両方で、より高速で、より小さく、よりリソース効率の高いJavaアプリケーションが実現します。"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/performance.html:15
 msgid "For example, at build time, Quarkus reads part of the application configuration, scans the classpath for annotated classes, and constructs a model of the application. By doing this early, Quarkus has enough information to eliminate unnecessary components and compute the exact startup instructions required."
 msgstr "例えば、ビルド時において、Quarkusはアプリケーション設定の一部を読み込み、アノテーションが付加されたクラスのクラスパスをスキャンし、アプリケーションのモデルを構築します。この早期処理により、Quarkusは不要なコンポーネントを排除し、必要な正確な起動命令を計算するのに十分な情報を得ることができます。"
 
 #. type: Attribute 'alt' of: <div><div><div><img><img>
-#. mt: gemini
 #: _includes/performance.html:18 _includes/performance.html:19
 msgid "Quarkus Build Time Principle"
 msgstr "Quarkus ビルド時原則"
 
 #. type: Content of: <div><div><div><p>
-#. mt: gemini
 #: _includes/performance.html:22
 msgid "This build-time optimization offers several key benefits:"
 msgstr "このビルド時最適化は、いくつかの主要な利点をもたらします。"
 
 #. type: Content of: <div><div><div><ol><li>
-#. mt: gemini
 #: _includes/performance.html:24
 msgid "<strong>Reduced startup time:</strong> Quarkus performs most of the heavy work at build-time, significantly cutting startup time and allowing the app to reach peak performance faster."
 msgstr "<strong>起動時間の短縮:</strong> Quarkusは、重い処理のほとんどをビルド時に実行するため、起動時間を大幅に短縮し、アプリがより早くピークパフォーマンスに到達できるようにします。"
 
 #. type: Content of: <div><div><div><ol><li>
-#. mt: gemini
 #: _includes/performance.html:25
 msgid "<strong>Lower memory consumption:</strong> By minimizing allocations and class loading, Quarkus reduces memory usage. Replacing reflection with build-time bytecode generation further lowers the JVM's runtime workload."
 msgstr "<strong>メモリ消費量の削減:</strong> 割り当てとクラスロードを最小限に抑えることで、Quarkusはメモリ使用量を削減します。リフレクションをビルド時のバイトコード生成に置き換えることで、JVMのランタイムワークロードがさらに軽減されます。"
 
 #. type: Content of: <div><div><div><ol><li>
-#. mt: gemini
 #: _includes/performance.html:26
 msgid "<strong>Better latency and improved throughput:</strong> Quarkus generates highly optimized code at build time and prunes unnecessary classes and methods. For instance, it weaves layers of indirection together, enabling better JIT optimizations. These improvements result in faster code and better latency."
 msgstr "<strong>より良いレイテンシーとスループットの向上:</strong> Quarkusは、ビルド時に高度に最適化されたコードを生成し、不要なクラスやメソッドを削除します。例えば、間接参照の層を結合することで、JIT最適化を向上させます。これらの改善により、より高速なコードとより良いレイテンシーが実現します。"
 
 #. type: Content of: <div><div><h2>
-#. mt: gemini
 #: _includes/performance.html:34
 msgid "High concurrency without the headaches: the reactive core"
 msgstr "煩わしさのない高い並行処理: リアクティブコア"
 
 #. type: Content of: <div><div><p>
-#. mt: gemini
 #: _includes/performance.html:35
 msgid "Quarkus is built on reactive principles, using an efficient asynchronous, non-blocking engine based on Netty and Eclipse Vert.x. It employs a few event loops instead of a large thread pool, reducing resource usage and improving response times by optimizing for hardware behavior."
 msgstr "Quarkusは、NettyとEclipse Vert.xに基づいた効率的な非同期・ノンブロッキングエンジンを使用するリアクティブ原則に基づいて構築されています。多数のスレッドプールではなく、少数のイベントループを採用することで、リソース使用量を削減し、ハードウェアの動作を最適化して応答時間を改善します。"
 
 #. type: Content of: <div><div><p>
-#. mt: gemini
 #: _includes/performance.html:36
 msgid "Reactive underneath does not mean you must write reactive code. Quarkus offers three development models:"
 msgstr "リアクティブが内部にあるからといって、リアクティブコードを書かなければならないわけではありません。Quarkusは3つの開発モデルを提供しています。"
 
 #. type: Content of: <div><div><ol><li>
-#. mt: gemini
 #: _includes/performance.html:38
 msgid "<strong>Imperative model:</strong> A traditional synchronous approach with faster execution due to an optimized I/O layer, ideal for lower concurrency. High concurrency increases memory use."
 msgstr "<strong>命令型モデル:</strong> 最適化されたI/Oレイヤーにより実行が高速化された従来の同期アプローチで、並行処理が少ない場合に最適です。高並行処理ではメモリ使用量が増加します。"
 
 #. type: Content of: <div><div><ol><li>
-#. mt: gemini
 #: _includes/performance.html:39
 msgid "<strong>Reactive model:</strong> Enables high concurrency with minimal resources using asynchronous, non-blocking code, but is more complex to implement and debug."
 msgstr "<strong>リアクティブモデル:</strong> 非同期のノンブロッキングコードを使用し、最小限のリソースで高い並行処理を可能にしますが、実装とデバッグがより複雑になります。"
 
 #. type: Content of: <div><div><ol><li>
-#. mt: gemini
 #: _includes/performance.html:40
 msgid "<strong>Virtual threads (JDK 21+):</strong> Combines the benefits of imperative and reactive models, allowing imperative code to run on lightweight virtual threads for high concurrency with low memory overhead, though some limitations remain."
 msgstr "<strong>仮想スレッド (JDK 21+):</strong> 命令型モデルとリアクティブモデルの利点を組み合わせ、命令型コードを軽量な仮想スレッドで実行することで、低いメモリオーバーヘッドで高い並行処理を可能にします。ただし、いくつかの制限は残ります。"
 
 #. type: Content of: <div><div><h2>
-#. mt: gemini
 #: _includes/performance.html:47
 msgid "What happens when the build time principle and the reactive core are combined?"
 msgstr "ビルド時原則とリアクティブコアが結合されるとどうなるでしょうか？"
 
 #. type: Content of: <div><div><p>
-#. mt: gemini
 #: _includes/performance.html:48
 msgid "The combination of the build time optimization and reactive core makes Quarkus a highly efficient framework, excelling in several key areas:"
 msgstr "ビルド時最適化とリアクティブコアの組み合わせにより、Quarkusは非常に効率的なフレームワークとなり、いくつかの主要な分野で優れています。"
 
 #. type: Attribute 'alt' of: <div><div><img><img>
-#. mt: gemini
 #: _includes/performance.html:51 _includes/performance.html:52
 msgid "Memory icon"
 msgstr "メモリのアイコン"
 
 #. type: Content of: <div><div><h3>
-#. mt: gemini
 #: _includes/performance.html:55
 msgid "Reduced Memory"
 msgstr "メモリ使用量の削減"
 
 #. type: Content of: <div><div><p>
-#. mt: gemini
 #: _includes/performance.html:56
 msgid "The build-time principle minimizes runtime memory use by eliminating unnecessary components and precomputing at build time, reducing class loading and memory allocations. The reactive core further cuts memory usage by using a few event loops instead of a large thread pool, allowing the application to handle higher loads with a smaller memory footprint and enabling high deployment density."
 msgstr "ビルド時原則は、不要なコンポーネントを排除し、ビルド時に事前計算を行うことで、ランタイムのメモリ使用量を最小限に抑え、クラスロードとメモリ割り当てを削減します。リアクティブコアは、多数のスレッドプールではなく少数のイベントループを使用することで、メモリ使用量をさらに削減し、アプリケーションがより少ないメモリフットプリントでより高い負荷を処理できるようにし、高いデプロイ密度を可能にします。"
 
 #. type: Attribute 'alt' of: <div><div><img><img>
-#. mt: gemini
 #: _includes/performance.html:59 _includes/performance.html:60
 msgid "Startup icon"
 msgstr "起動のアイコン"
 
 #. type: Content of: <div><div><h3>
-#. mt: gemini
 #: _includes/performance.html:63
 msgid "Fast Startup Time"
 msgstr "高速な起動時間"
 
 #. type: Content of: <div><div><p>
-#. mt: gemini
 #: _includes/performance.html:64
 msgid "Thanks to the build-time optimizations, most of the application’s heavy lifting, such as classpath scanning, configuration loading, and dependency injection setup, happens before the application even starts. This significantly reduces the time it takes to get the application up and ready to serve. The reactive core contributes to this by ensuring that I/O operations are handled with minimal blocking, further reducing the startup latency.  The efficient startup process means the application can respond to new load conditions more quickly. This combination supports implementing LightSwitchOps patterns, enabling elasticity while controlling costs."
 msgstr "ビルド時の最適化のおかげで、クラスパススキャン、設定ロード、依存性注入のセットアップといったアプリケーションの重い処理のほとんどは、アプリケーションが起動する前に完了します。これにより、アプリケーションが立ち上がり、サービスを提供する準備が整うまでの時間が大幅に短縮されます。リアクティブコアは、I/O操作が最小限のブロッキングで処理されることを保証することでこれに貢献し、起動レイテンシーをさらに削減します。効率的な起動プロセスは、アプリケーションが新しい負荷条件に迅速に対応できることを意味します。この組み合わせは、LightSwitchOpsパターンを実装し、コストを抑えながら弾力性を実現することをサポートします。"
 
 #. type: Attribute 'alt' of: <div><div><img><img>
-#. mt: gemini
 #: _includes/performance.html:67 _includes/performance.html:68
 msgid "Throughput icon"
 msgstr "スループットのアイコン"
 
 #. type: Content of: <div><div><h3>
-#. mt: gemini
 #: _includes/performance.html:71
 msgid "High Throughput"
 msgstr "高いスループット"
 
 #. type: Content of: <div><div><p>
-#. mt: gemini
 #: _includes/performance.html:72
 msgid "Build-time optimizations ensure tasks like classpath scanning, configuration loading, and dependency injection are completed before startup, greatly reducing startup time. This efficient startup enables quicker responses to load changes and supports LightSwitchOps patterns for cost-effective elasticity. The reactive core minimizes blocking in I/O operations, further lowering latency and allowing handling a large number of concurrent tasks."
 msgstr "ビルド時の最適化により、クラスパススキャン、設定のロード、依存性注入などのタスクは起動前に完了し、起動時間を大幅に短縮します。この効率的な起動により、負荷の変化に迅速に対応でき、費用対効果の高い弾力性を実現するLightSwitchOpsパターンをサポートします。リアクティブコアは、I/O操作でのブロッキングを最小限に抑え、レイテンシーをさらに低減し、多数の同時タスクを処理できるようにします。"
 
 #. type: Attribute 'alt' of: <div><div><img><img>
-#. mt: gemini
 #: _includes/performance.html:75 _includes/performance.html:76
 msgid "Disk footprint icon"
 msgstr "ディスクフットプリントのアイコン"
 
 #. type: Content of: <div><div><h3>
-#. mt: gemini
 #: _includes/performance.html:79
 msgid "Optimized Resource Consumption"
 msgstr "最適化されたリソース消費"
 
 #. type: Content of: <div><div><p>
-#. mt: gemini
 #: _includes/performance.html:80
 msgid "The build-time principle and reactive core optimize CPU, memory, and system resource use, enabling high performance with fewer resources. This lowers operational costs in cloud environments and offers sustainability benefits through reduced resource consumption."
 msgstr "ビルド時原則とリアクティブコアは、CPU、メモリ、システムリソースの使用を最適化し、より少ないリソースで高いパフォーマンスを実現します。これにより、クラウド環境での運用コストが削減され、リソース消費の低減を通じて持続可能性のメリットも提供されます。"
 
 #. type: Content of: <div><div><h2>
-#. mt: gemini
 #: _includes/performance.html:85
 msgid "Continuously Measuring, Continuously Improving"
 msgstr "継続的な測定、継続的な改善"
 
 #. type: Content of: <div><div><p>
-#. mt: gemini
 #: _includes/performance.html:86
 msgid "Quarkus is dedicated to continuously improving performance, especially for code running on the critical execution (hot) path. Through ongoing optimizations, Quarkus ensures that every instruction and allocated byte matters, making it one of the most efficient frameworks available for developing <a href=\"https://www.techempower.com/benchmarks/#hw=ph&test=fortune&section=data-r22&c=e&f=0-0-0-0-0-0-0-0-0-2-4zsow-0-0-0-0&l=5181v-6bl\">high-performance, cloud-ready applications.</a>"
 msgstr "Quarkusは、特にクリティカルな実行（ホット）パスで実行されるコードのパフォーマンスを継続的に改善することに専念しています。継続的な最適化を通じて、Quarkusはすべての命令と割り当てられたバイトが重要であることを保証し、<a href=\"https://www.techempower.com/benchmarks/#hw=ph&test=fortune&section=data-r22&c=e&f=0-0-0-0-0-0-0-0-0-2-4zsow-0-0-0-0&l=5181v-6bl\">高性能なクラウド対応アプリケーション</a>を開発するための最も効率的なフレームワークの1つにしています。"
 
 #. type: Content of: <div><div><h2>
-#. mt: gemini
 #: _includes/performance.html:87
 msgid "Related Links"
 msgstr "関連リンク"
 
 #. type: Content of: <div><div><p>
-#. mt: gemini
 #: _includes/performance.html:88
 msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"https://quarkus.io/blog/reactive-crud-performance-case-study/\">\"Reactive CRUD Performance: A Case Study\" Blog Post</a>"
 msgstr "<i class=\"fa fa-chevron-right\"></i><a href=\"https://quarkus.io/blog/reactive-crud-performance-case-study/\">「Reactive CRUD Performance: A Case Study」ブログ投稿</a>"
 
 #. type: Content of: <div><div><p>
-#. mt: gemini
 #: _includes/performance.html:89
 msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"https://quarkus.io/guides/performance-measure\">\"Measuring Performance\" guide</a>"
 msgstr "<i class=\"fa fa-chevron-right\"></i><a href=\"https://quarkus.io/guides/performance-measure\">「パフォーマンス測定」ガイド</a>"

--- a/l10n/po/ja_JP/_includes/training-band.html.po
+++ b/l10n/po/ja_JP/_includes/training-band.html.po
@@ -1,0 +1,60 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Content of: <div><div><div><h3>
+#: _includes/training-band.html:4
+msgid "{{ site.data.training.headline }}"
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/training-band.html:5
+msgid "{{ site.data.training.disclaimer }}"
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/training-band.html:6
+msgid "{{ site.data.training.addtraining }}"
+msgstr ""
+
+#. type: Content of: <div><div>
+#: _includes/training-band.html:9
+msgid "{% for item in site.data.training.courses %}"
+msgstr ""
+
+#. type: Content of: <div><div><div>
+#: _includes/training-band.html:11
+msgid "<a href=\"{{item.url}}\" target=\"blank\"></a>"
+msgstr ""
+
+#. type: Content of: <div><div><div><p>
+#: _includes/training-band.html:12
+msgid "{{ item.affiliation }}"
+msgstr ""
+
+#. type: Content of: <div><div><div><div>
+#: _includes/training-band.html:14
+msgid "{{ item.descr }}"
+msgstr ""
+
+#. type: Content of: <div><div><div><div>
+#: _includes/training-band.html:17
+msgid "Course Type: {{ item.type }}"
+msgstr ""
+
+#. type: Content of: <div><div><div><div>
+#: _includes/training-band.html:18
+msgid "Course Language: {{ item.language }}"
+msgstr ""
+
+#. type: Content of: <div><div>
+#: _includes/training-band.html:21
+msgid "{% endfor %}"
+msgstr ""

--- a/l10n/po/ja_JP/_includes/userstories-band.html.po
+++ b/l10n/po/ja_JP/_includes/userstories-band.html.po
@@ -10,67 +10,56 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Content of: <div><div>
-#. mt: gemini
 #: _includes/userstories-band.html:6
 msgid "{% for post in site.tags.user-story %} {% assign author = site.data.authors[post.author] %}"
 msgstr "{% for post in site.tags.user-story %} {% assign author = site.data.authors[post.author] %}"
 
 #. type: Content of: <div><div><div>
-#. mt: gemini
 #: _includes/userstories-band.html:9
 msgid "<a href=\"{{site.baseurl}}{{ post.url }}\"></a>"
 msgstr "<a href=\"{{site.baseurl}}{{ post.url }}\"></a>"
 
 #. type: Content of: <div><div><div><div>
-#. mt: gemini
 #: _includes/userstories-band.html:11
 msgid "{% if post.thumbnailimage %}"
 msgstr "{% if post.thumbnailimage %}"
 
 #. type: Content of: <div><div><div><div><img><div>
-#. mt: gemini
 #: _includes/userstories-band.html:13 _includes/userstories-band.html:20
 msgid "{% endif %}"
 msgstr "{% endif %}"
 
 #. type: Content of: <div><div><div><div><img><p>
-#. mt: gemini
 #: _includes/userstories-band.html:14
 msgid "{{ post.title }}"
 msgstr "{{ post.title }}"
 
 #. type: Content of: <div><div><div><div><img><div>
-#. mt: gemini
 #: _includes/userstories-band.html:16
 msgid "{% if post.synopsis %}"
 msgstr "{% if post.synopsis %}"
 
 #. type: Content of: <div><div><div><div><img><div><p>
-#. mt: gemini
 #: _includes/userstories-band.html:17
 msgid "{{ post.synopsis | strip_html }}"
 msgstr "{{ post.synopsis | strip_html }}"
 
 #. type: Content of: <div><div><div><div><img><div>
-#. mt: gemini
 #: _includes/userstories-band.html:18
 msgid "{% else %}"
 msgstr "{% else %}"
 
 #. type: Content of: <div><div><div><div><img><div><p>
-#. mt: gemini
 #: _includes/userstories-band.html:19
 msgid "{{ post.content | strip_html | truncate: 200 }}"
 msgstr "{{ post.content | strip_html | truncate: 200 }}"
 
 #. type: Content of: <div><div><div><div><img><div>
-#. mt: gemini
 #: _includes/userstories-band.html:21
 msgid "Written by: {% if post.author %} {{ author.name }} {% endif %}"
 msgstr "Written by: {% if post.author %} {{ author.name }} {% endif %}"
 
 #. type: Content of: <div><div>
-#. mt: gemini
 #: _includes/userstories-band.html:24
 msgid "{% endfor %}"
 msgstr "{% endfor %}"


### PR DESCRIPTION
## Summary

This PR adds 14 new HTML files to the translation extraction configuration, enabling translation of additional user-facing content.

## Added Files

### AI-related content (7 files)
- `ai-blueprints.html` - AI design patterns
- `ai-chainofthought.html` - Chain of Thought pattern
- `ai-contextualrag.html` - Contextual RAG
- `ai-frozenrag.html` - Frozen RAG
- `ai-java-for-ai.html` - Java for AI
- `ai-overview.html` - AI overview
- `ai-quarkus-for-ai.html` - Quarkus for AI (LangChain4j)

### Community and support (3 files)
- `benefactors.html` - Quarkus benefactors (IBM, Red Hat, AWS, GitHub, RunsOn, Gradle, Zulip)
- `CF-footerband.html` - Footer with copyright and trademark information
- `homepage-commonhaus-band.html` - Commonhaus Foundation introduction

### Spring migration (2 files)
- `spring-features-band.html` - Spring compatibility features
- `spring-migrate-main.html` - Spring migration guide

### Other (2 files)
- `newsletter-band.html` - Newsletter section
- `training-band.html` - Training resources

## Next Steps

After this PR is merged, run `./tsujiw jekyll extract` to generate the PO files for these new HTML files.