### PR TITLE
Translate 10 new HTML include files

### DIFF
--- a/l10n/po/ja_JP/_includes/CF-footerband.html.po
+++ b/l10n/po/ja_JP/_includes/CF-footerband.html.po
@@ -10,16 +10,19 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Content of: <div><div><div><a>
+#. mt: gemini
 #: _includes/CF-footerband.html:4
 msgid "<a class=\"cf-logo\" href=\"https://www.commonhaus.org/\" target=\"_blank\">"
-msgstr ""
+msgstr "<a class=\"cf-logo\" href=\"https://www.commonhaus.org/\" target=\"_blank\">"
 
 #. type: Content of: <div><div><div>
+#. mt: gemini
 #: _includes/CF-footerband.html:4
 msgid "</a>"
-msgstr ""
+msgstr "</a>"
 
 #. type: Content of: <div><div><div>
+#. mt: gemini
 #: _includes/CF-footerband.html:7
 msgid "Copyright © Quarkus. All rights reserved. For details on our trademarks, please visit our <a href=\"https://www.commonhaus.org/policies/trademark-policy/\">Trademark Policy</a> and <a href=\"https://www.commonhaus.org/trademarks/\">Trademark List</a>. Trademarks of third parties are owned by their respective holders and their mention here does not suggest any endorsement or association."
-msgstr ""
+msgstr "Copyright © Quarkus. 全著作権所有。当社の商標の詳細については、<a href=\"https://www.commonhaus.org/policies/trademark-policy/\">商標ポリシー</a>および<a href=\"https://www.commonhaus.org/trademarks/\">商標リスト</a>をご覧ください。第三者の商標は、それぞれの所有者に帰属し、ここに記載されていることは、いかなる推奨や関連も示唆するものではありません。"

--- a/l10n/po/ja_JP/_includes/ai-blueprints.html.po
+++ b/l10n/po/ja_JP/_includes/ai-blueprints.html.po
@@ -10,71 +10,85 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Attribute 'alt' of: <div><div><div><img><img>
+#. mt: gemini
 #: _includes/ai-blueprints.html:4 _includes/ai-blueprints.html:5
 msgid "AI blueprints icon"
-msgstr ""
+msgstr "AIブループリントアイコン"
 
 #. type: Content of: <div><div><div><h2>
+#. mt: gemini
 #: _includes/ai-blueprints.html:8
 msgid "Enterprise AI Blueprints for Java with Quarkus & LangChain4j"
-msgstr ""
+msgstr "QuarkusとLangChain4jによるJava向けエンタープライズAIブループリント"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-blueprints.html:9
 msgid "The following three blueprints are conceptual, infrastructure-agnostic reference architectures. Each stands on its own and shows how to structure a Java solution with Quarkus (runtime, APIs, orchestration) and LangChain4j (LLM access, embeddings, tools, chains)."
-msgstr ""
+msgstr "以下の3つのブループリントは、概念的でインフラストラクチャーに依存しないリファレンスアーキテクチャーです。それぞれが独立しており、Quarkus（ランタイム、API、オーケストレーション）とLangChain4j（LLMアクセス、埋め込み、ツール、チェーン）を使用してJavaソリューションを構築する方法を示しています。"
 
 #. type: Content of: <div><div><div><p><p><p>
+#. mt: gemini
 #: _includes/ai-blueprints.html:10
 msgid "Quarkus provides the foundation for building secure, cloud-native, and AI-infused applications. Quarkus applications integrate with external model runtimes through LangChain4j, which offers rich abstractions for connecting to LLM providers, managing embeddings, defining tools, and orchestrating agentic workflows. This keeps AI where it belongs, as a capability embedded in enterprise applications, while Quarkus ensures performance, scalability, and operational reliability."
-msgstr ""
+msgstr "Quarkusは、セキュアでクラウドネイティブ、そしてAIが組み込まれたアプリケーションを構築するための基盤を提供します。Quarkusアプリケーションは、LangChain4jを介して外部モデルランタイムと統合されます。LangChain4jは、LLMプロバイダーへの接続、埋め込みの管理、ツールの定義、およびエージェントワークフローのオーケストレーションのための豊富な抽象化を提供します。これにより、AIはエンタープライズアプリケーションに組み込まれた機能として、本来あるべき場所に配置され、同時にQuarkusはパフォーマンス、スケーラビリティ、運用上の信頼性を保証します。"
 
 #. type: Content of: <div><div><div><p><p><p><p><p>
+#. mt: gemini
 #: _includes/ai-blueprints.html:11
 msgid "These blueprints demonstrate practical patterns and best practices for developing enterprise-grade AI solutions using a combination of these technologies. They aim to simplify the process of using AI in Java applications and guiding software architects along the way. Whether you're building intelligent chatbots, recommendation engines, or sophisticated data analysis tools, these blueprints provide a solid starting point for your next AI project. Explore each blueprint to discover how Quarkus and LangChain4j can enrich your Java applications with advanced AI capabilities."
-msgstr ""
+msgstr "これらのブループリントは、これらのテクノロジーの組み合わせを使用してエンタープライズグレードのAIソリューションを開発するための実践的なパターンとベストプラクティスを示します。これらは、JavaアプリケーションでのAIの使用プロセスを簡素化し、ソフトウェアアーキテクトを導くことを目的としています。インテリジェントなチャットボット、レコメンデーションエンジン、高度なデータ分析ツールを構築しているかどうかにかかわらず、これらのブループリントは次のAIプロジェクトのための確かな出発点を提供します。各ブループリントを調べて、QuarkusとLangChain4jが高度なAI機能でJavaアプリケーションをどのように豊かにできるかを発見してください。"
 
 #. type: Content of: <div><div><div><h3>
+#. mt: gemini
 #: _includes/ai-blueprints.html:15
 msgid "Frozen RAG (Retrieval-Augmented Generation)"
-msgstr ""
+msgstr "Frozen RAG (検索拡張生成)"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-blueprints.html:16
 msgid "Improve LLM accuracy with RAG, leveraging enterprise data. Quarkus handles RAG's entire process, including data ingestion, query execution, embedding, context retrieval, and LLM communication."
-msgstr ""
+msgstr "エンタープライズデータを活用したRAGにより、LLMの精度を向上させます。Quarkusは、データ取り込み、クエリ実行、埋め込み、コンテキスト取得、LLM通信を含むRAGのプロセス全体を処理します。"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-blueprints.html:17
 msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/ai-frozen-rag\">Learn the basics of Frozen RAG</a>"
-msgstr ""
+msgstr "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/ai-frozen-rag\">Frozen RAGの基本を学ぶ</a>"
 
 #. type: Content of: <div><div><div><h3>
+#. mt: gemini
 #: _includes/ai-blueprints.html:21
 msgid "Contextual RAG (Multi-Sources, Rerank, Injection)"
-msgstr ""
+msgstr "コンテキストRAG (マルチソース、再ランク付け、注入)"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-blueprints.html:22
 msgid "Advanced Contextual RAG improves frozen RAG by adding multi-source retrieval, reranking, and content injection. This makes it ideal for complex enterprise scenarios, ensuring accuracy, relevance, and explainability across distributed information. It enables dynamic information handling, complex queries, and clear lineage for auditable, high-stakes decisions."
-msgstr ""
+msgstr "高度なコンテキストRAGは、マルチソース検索、再ランク付け、およびコンテンツ注入を追加することで、Frozen RAGを改善します。これにより、複雑なエンタープライズシナリオに最適となり、分散情報全体で精度、関連性、説明可能性を保証します。動的な情報処理、複雑なクエリ、および監査可能で重要な意思決定のための明確な系統を可能にします。"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-blueprints.html:23
 msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/ai-contextual-rag\">Learn about Contextual RAG </a>"
-msgstr ""
+msgstr "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/ai-contextual-rag\">コンテキストRAGについて学ぶ</a>"
 
 #. type: Content of: <div><div><div><h3>
+#. mt: gemini
 #: _includes/ai-blueprints.html:27
 msgid "Chain-of-Thought (CoT) Reasoning"
-msgstr ""
+msgstr "思考連鎖 (CoT) 推論"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-blueprints.html:28
 msgid "Chain-of-Thought (CoT) guides LLMs through explicit intermediate steps to solve complex problems. This systematic approach breaks tasks into manageable sub-problems for sequential processing and solution building. CoT enhances LLM accuracy, enabling understanding and debugging, especially for multi-step reasoning in mathematical problem-solving, code generation, and logical inference."
-msgstr ""
+msgstr "思考連鎖 (CoT) は、明示的な中間ステップを通じてLLMを導き、複雑な問題を解決します。この系統的なアプローチは、タスクを管理可能なサブ問題に分解し、シーケンシャル処理とソリューション構築を行います。CoTはLLMの精度を向上させ、特に数学的問題解決、コード生成、論理的推論における多段階推論において、理解とデバッグを可能にします。"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-blueprints.html:29
 msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/ai-chain-of-thought\">Learn about Chain-of-Thought Reasoning</a>"
-msgstr ""
+msgstr "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/ai-chain-of-thought\">思考連鎖推論について学ぶ</a>"

--- a/l10n/po/ja_JP/_includes/ai-chainofthought.html.po
+++ b/l10n/po/ja_JP/_includes/ai-chainofthought.html.po
@@ -10,146 +10,175 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Content of: <div><div><div><h1>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:4
 msgid "Chain-of-Thought (CoT) Reasoning"
-msgstr ""
+msgstr "Chain-of-Thought (CoT) 推論"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:5
 msgid "The architecture of the Chain-of-Thought (CoT) blueprint focuses on guiding a Large Language Model (LLM) through explicit intermediate steps to solve complex problems, improve reasoning, and provide transparency in its decision-making."
-msgstr ""
+msgstr "Chain-of-Thought (CoT) ブループリントのアーキテクチャは、大規模言語モデル (LLM) を明示的な中間ステップを通じてガイドし、複雑な問題を解決し、推論を改善し、その意思決定に透明性を提供することに焦点を当てています。"
 
 #. type: Content of: <div><div><div><h2>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:6
 msgid "Main Use-Cases"
-msgstr ""
+msgstr "主なユースケース"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:8
 msgid "<strong>Improved Reasoning:</strong> Decompose complex problems to reduce logical errors."
-msgstr ""
+msgstr "<strong>推論の改善:</strong> 複雑な問題を分解して、論理的誤りを減らします。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:9
 msgid "<strong>Transparency:</strong> Provide optional explanations for decisions."
-msgstr ""
+msgstr "<strong>透明性:</strong> 意思決定に関するオプションの説明を提供します。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:10
 msgid "<strong>Training & Enablement:</strong> Illustrate the \"why\" behind concepts, not just the \"what.\""
-msgstr ""
+msgstr "<strong>トレーニングとイネーブルメント:</strong> 概念の「何を」だけでなく、「なぜ」を説明します。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:11
 msgid "<strong>Decision Support:</strong> Aid in investments, vendor selection, and risk assessments."
-msgstr ""
+msgstr "<strong>意思決定支援:</strong> 投資、ベンダー選定、リスク評価を支援します。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:12
 msgid "<strong>Troubleshooting:</strong> Facilitate structured diagnostics in operations and engineering."
-msgstr ""
+msgstr "<strong>トラブルシューティング:</strong> 運用およびエンジニアリングにおいて、構造化された診断を容易にします。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:13
 msgid "<strong>Policy Application:</strong> Apply multi-clause rules with traceable steps."
-msgstr ""
+msgstr "<strong>ポリシー適用:</strong> 追跡可能なステップで複数条項のルールを適用します。"
 
 #. type: Content of: <div><div><div><h2>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:15
 msgid "Architecture Overview"
-msgstr ""
+msgstr "アーキテクチャの概要"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:16
 msgid "The CoT architecture starts with a \"User Query\" that initiates the process. This query is received by the \"Quarkus CoT Service,\" which serves as the orchestrator for the entire reasoning flow. Within the Quarkus service, the core Chain-of-Thought logic, powered by LangChain4j, is executed."
-msgstr ""
+msgstr "CoT アーキテクチャは、プロセスを開始する「ユーザー クエリ」から始まります。このクエリは、「Quarkus CoT サービス」によって受信され、このサービスが推論フロー全体のオーケストレーターとして機能します。Quarkus サービス内で、LangChain4j を活用したコアの Chain-of-Thought ロジックが実行されます。"
 
 #. type: Attribute 'alt' of: <div><div><div><img><img>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:17 _includes/ai-chainofthought.html:18
 msgid "CoT architecture image"
-msgstr ""
+msgstr "CoT アーキテクチャ図"
 
 #. type: Content of: <div><div><div><img><img><p>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:19
 msgid "The \"LangChain4j\" package encapsulates the sequential steps of the CoT process:"
-msgstr ""
+msgstr "「LangChain4j」パッケージは、CoT プロセスの連続するステップをカプセル化します。"
 
 #. type: Content of: <div><div><div><dl><dt>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:23
 msgid "Step 1: Analyze Factors:"
-msgstr ""
+msgstr "ステップ1: 要因分析:"
 
 #. type: Content of: <div><div><div><dl><dd>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:24
 msgid "This initial step involves the LLM breaking down the complex user query into its constituent parts, identifying key factors, and performing an initial analysis. This could involve understanding the problem, identifying relevant data points, or defining the scope of the task."
-msgstr ""
+msgstr "この最初のステップでは、LLM が複雑なユーザー クエリを構成要素に分解し、主要な要因を特定し、初期分析を実行します。これには、問題の理解、関連データポイントの特定、またはタスクの範囲の定義が含まれる場合があります。"
 
 #. type: Content of: <div><div><div><dl><dt>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:29
 msgid "Step 2: Synthesize Options:"
-msgstr ""
+msgstr "ステップ2: オプションの統合:"
 
 #. type: Content of: <div><div><div><dl><dd>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:30
 msgid "Building on the analysis from Step 1, the LLM then synthesizes various options, potential solutions, or different perspectives related to the query. This step demonstrates the model's ability to explore different avenues of thought before arriving at a conclusion."
-msgstr ""
+msgstr "ステップ1の分析に基づいて、LLM はクエリに関連するさまざまなオプション、潜在的な解決策、または異なる視点を統合します。このステップは、モデルが結論に達する前にさまざまな思考経路を探る能力を示しています。"
 
 #. type: Content of: <div><div><div><dl><dt>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:35
 msgid "Step 3: Recommendation:"
-msgstr ""
+msgstr "ステップ3: 推奨:"
 
 #. type: Content of: <div><div><div><dl><dd>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:36
 msgid "In the final step, the LLM formulates a \"Recommendation\" or a definitive answer based on the analysis and synthesis performed in the preceding steps. This recommendation is the ultimate output of the CoT process."
-msgstr ""
+msgstr "最終ステップでは、LLM は前のステップで実行された分析と統合に基づいて、「推奨」または決定的な回答を策定します。この推奨が CoT プロセスの最終出力となります。"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:40
 msgid "Finally, the Response is returned to the user, with the option to include the intermediate reasoning steps when transparency is required. Quarkus orchestrates the execution of single- or multi-prompt chains, while LangChain4j supplies the abstractions for building prompts and capturing reasoning outputs at each step. This structured flow improves the LLM’s performance on complex tasks and, when needed, provides an auditable record of how the answer was derived."
-msgstr ""
+msgstr "最後に、応答がユーザーに返され、透明性が必要な場合には中間推論ステップを含めるオプションが提供されます。Quarkus はシングルプロンプトまたはマルチプロンプトのチェーンの実行をオーケストレーションし、LangChain4j はプロンプトを構築し、各ステップでの推論出力をキャプチャするための抽象化を提供します。この構造化されたフローにより、複雑なタスクにおける LLM のパフォーマンスが向上し、必要に応じて回答がどのように導き出されたかを示す監査可能な記録が提供されます。"
 
 #. type: Content of: <div><div><div><h2>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:41
 msgid "Further Patterns"
-msgstr ""
+msgstr "さらなるパターン"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:42
 msgid "Further patterns in Chain-of-Thought reasoning extend beyond basic single-prompt approaches to offer more sophisticated control and integration. \"Single-prompt CoT\" provides a concise way to elicit reasoning, where a single instruction like \"think step by step\" guides the LLM to return both its thought process and the final answer."
-msgstr ""
+msgstr "Chain-of-Thought 推論におけるさらなるパターンは、基本的なシングルプロンプトのアプローチを超えて、より洗練された制御と統合を提供します。「シングルプロンプト CoT」は、たとえば「段階的に考える」といった単一の指示によって LLM が思考プロセスと最終回答の両方を返すように導く、簡潔な推論の引き出し方を提供します。"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:43
 msgid "More advanced scenarios benefit from \"Program-of-Thought,\" which involves multiple chained prompts, where the output of one step feeds into the next, often including optional verification steps for enhanced accuracy."
-msgstr ""
+msgstr "より高度なシナリオでは、「Program-of-Thought」の恩恵を受けます。これは、複数の連結されたプロンプトを含み、あるステップの出力が次のステップに供給され、多くの場合、精度を高めるためのオプションの検証ステップが含まれます。"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:44
 msgid "Lastly, a \"Hybrid\" approach combines CoT with Retrieval-Augmented Generation (RAG) to ground the reasoning process in factual information, ensuring that the LLM's logical steps are supported by relevant data. These patterns provide flexibility in how CoT is applied, allowing architects to choose the level of control and factual grounding necessary for their specific enterprise AI applications."
-msgstr ""
+msgstr "最後に、「ハイブリッド」アプローチは、CoT と Retrieval-Augmented Generation (RAG) を組み合わせ、推論プロセスを事実情報に基づいて確立することで、LLM の論理的ステップが関連データによってサポートされていることを保証します。これらのパターンは、CoT の適用方法に柔軟性をもたらし、アーキテクトが特定のエンタープライズ AI アプリケーションに必要な制御レベルと事実に基づいた基盤を選択できるようにします。"
 
 #. type: Content of: <div><div><div><h2>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:45
 msgid "Guardrails & Privacy"
-msgstr ""
+msgstr "ガードレールとプライバシー"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:46
 msgid "Architecting Chain-of-Thought (CoT) solutions for enterprise environments necessitates careful consideration of guardrails and privacy. The following points represent an initial excerpt of critical aspects that software architects must account for to ensure responsible and secure AI deployment. These considerations are vital to manage the transparency of reasoning, maintain answer consistency, and control data exposure within the CoT process."
-msgstr ""
+msgstr "エンタープライズ環境向けの Chain-of-Thought (CoT) ソリューションを設計するには、ガードレールとプライバシーの慎重な検討が必要です。以下の点は、責任ある安全な AI 展開を確実にするためにソフトウェアアーキテクトが考慮しなければならない重要な側面の一部を示しています。これらの考慮事項は、推論の透明性を管理し、回答の一貫性を維持し、CoT プロセス内でのデータ漏洩を制御するために不可欠です。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:48
 msgid "<strong>Reasoning Exposure:</strong> Decide whether to reveal the Chain of Thought (CoT) or keep it internal."
-msgstr ""
+msgstr "<strong>推論の開示:</strong> Chain of Thought (CoT) を開示するか、内部に留めるかを決定します。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:49
 msgid "<strong>Consistency Checks:</strong> Implement a final verifier prompt or apply deterministic post-rules."
-msgstr ""
+msgstr "<strong>一貫性チェック:</strong> 最終検証プロンプトを実装するか、決定論的な後処理ルールを適用します。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-chainofthought.html:50
 msgid "<strong>Token Budgeting:</strong> Limit intermediate verbosity and summarize between steps."
-msgstr ""
+msgstr "<strong>トークン予算管理:</strong> 中間的な冗長性を制限し、ステップ間で要約します。"

--- a/l10n/po/ja_JP/_includes/ai-contextualrag.html.po
+++ b/l10n/po/ja_JP/_includes/ai-contextualrag.html.po
@@ -10,151 +10,181 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Content of: <div><div><div><h1>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:4
 msgid "Contextual RAG (Multi-Sources, Rerank, Injection)"
-msgstr ""
+msgstr "コンテキストRAG (複数ソース、再ランク付け、注入)"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:5
 msgid "Advanced Contextual RAG extends the core frozen RAG pattern by incorporating multi-source retrieval, reranking, and content injection techniques. This is designed for more complex enterprise scenarios where information might be spread across various systems, requiring more sophisticated methods to ensure accuracy, relevance, and explainability. It allows for dynamic information handling, complex query processing, and provides clearer lineage for auditable decisions, making it ideal for high-stakes applications."
-msgstr ""
+msgstr "高度なコンテキストRAGは、複数ソースからの情報検索、再ランク付け、コンテンツ注入技術を組み込むことで、コアなフローズンRAGパターンを拡張します。これは、情報がさまざまなシステムに分散している可能性があり、正確性、関連性、説明可能性を確保するためにより洗練された手法が必要となる、より複雑な企業シナリオ向けに設計されています。これにより、動的な情報処理、複雑なクエリ処理が可能になり、監査可能な決定のためのより明確な系譜が提供されるため、高いリスクを伴うアプリケーションに最適です。"
 
 #. type: Content of: <div><div><div><h2>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:6
 msgid "Main Use-Cases"
-msgstr ""
+msgstr "主なユースケース"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:8
 msgid "<strong>Complex Queries:</strong> Addresses intricate questions requiring synthesis from multiple sources."
-msgstr ""
+msgstr "<strong>複雑なクエリ:</strong> 複数のソースからの統合を必要とする複雑な問題に対応します。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:9
 msgid "<strong>Dynamic Information:</strong> Handles rapidly changing data environments by incorporating real-time updates."
-msgstr ""
+msgstr "<strong>動的な情報:</strong> リアルタイムの更新を組み込むことで、急速に変化するデータ環境に対応します。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:10
 msgid "<strong>High-Accuracy Needs:</strong> Reranking and injection ensure more precise and relevant answers."
-msgstr ""
+msgstr "<strong>高精度なニーズ:</strong> 再ランク付けと注入により、より正確で関連性の高い回答が保証されます。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:11
 msgid "<strong>Auditable Decisions:</strong> Provides clear lineage and context for generated responses, crucial for compliance and debugging."
-msgstr ""
+msgstr "<strong>監査可能な決定:</strong> 生成された応答について明確な系譜とコンテキストを提供し、コンプライアンスとデバッグに不可欠です。"
 
 #. type: Content of: <div><div><div><h2>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:13
 msgid "Architecture Overview"
-msgstr ""
+msgstr "アーキテクチャの概要"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:14
 msgid "The process begins with a User Query, which is first processed by a Query Transformer to refine or enhance it for more effective retrieval. The transformed query is then passed to a Query Router that decides which knowledge sources to target. For unstructured data, the ingestion pipeline remains the same as in the foundational RAG architecture (documents split, embedded, and stored in a vector store), but contextual RAG extends retrieval to multiple sources such as structured databases, APIs, and search indexes."
-msgstr ""
+msgstr "このプロセスはユーザーのクエリから始まり、まずクエリ変換器によって、より効果的な検索のために洗練または強化されます。変換されたクエリは、次にクエリルーティングに渡され、どの知識ソースをターゲットにするかを決定します。非構造化データの場合、取り込みパイプラインは基本的なRAGアーキテクチャ (ドキュメントは分割され、埋め込み化され、ベクトルストアに保存されます) と同じですが、コンテキストRAGは、構造化データベース、API、検索インデックスなどの複数ソースに情報検索を拡張します。"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:15
 msgid "The <strong>Query Router</strong> is responsible for directing the query to multiple retrieval sources simultaneously. These sources include:"
-msgstr ""
+msgstr "<strong>クエリルーティング</strong>は、クエリを複数の検索ソースに同時に指示する役割を担います。これらのソースには以下が含まれます:"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:17
 msgid "<strong>Vector Retriever:</strong> Retrieves information based on semantic similarity from a vector store."
-msgstr ""
+msgstr "<strong>ベクトル検索器:</strong> ベクトルストアからセマンティックな類似性に基づいて情報を検索します。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:18
 msgid "<strong>Web/Search Retriever:</strong> Gathers information from the web or external search engines."
-msgstr ""
+msgstr "<strong>Web/検索検索器:</strong> Webまたは外部の検索エンジンから情報を収集します。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:19
 msgid "<strong>Database Retriever:</strong> Extracts relevant data from structured databases."
-msgstr ""
+msgstr "<strong>データベース検索器:</strong> 構造化データベースから関連データを抽出します。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:20
 msgid "<strong>Full-Text Retriever:</strong> Performs keyword-based searches across a corpus of documents."
-msgstr ""
+msgstr "<strong>全文検索器:</strong> 文書コーパス全体でキーワードに基づいた検索を実行します。"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:22
 msgid "All the information retrieved from these diverse sources is then fed into an <strong>Aggregator/Reranker</strong>. This component combines and prioritizes the retrieved content based on relevance to the original query."
-msgstr ""
+msgstr "これらの多様なソースから検索されたすべての情報は、その後、<strong>アグリゲーター/再ランク付け器</strong>に供給されます。このコンポーネントは、元のクエリへの関連性に基づいて、検索されたコンテンツを結合し、優先順位を付けます。"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:23
 msgid "The aggregated and reranked content is passed to a <strong>Content Injector (Prompt Builder)</strong>. This component constructs an Enhanced Prompt for the Large Language Model (LLM) by incorporating the retrieved context alongside the original user query."
-msgstr ""
+msgstr "集約され、再ランク付けされたコンテンツは、<strong>コンテンツ注入器 (プロンプトビルダー)</strong>に渡されます。このコンポーネントは、検索されたコンテキストを元のユーザーのクエリと一緒に組み込むことで、大規模言語モデル (LLM) のために強化されたプロンプトを構築します。"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:24
 msgid "Finally, the LLM processes the <strong>Augmented Prompt</strong>, using the provided context to generate an answer. Alongside the answer, the system can return the retrieved source segments for transparency and verification, though these should be considered supporting context rather than strict citations."
-msgstr ""
+msgstr "最後に、LLMは提供されたコンテキストを使用して回答を生成するため、<strong>オーグメンテーションされたプロンプト</strong>を処理します。回答と並行して、システムは透明性と検証のために検索されたソースセグメントを返すことができますが、これらは厳密な引用ではなく、補助的なコンテキストと見なされるべきです。"
 
 #. type: Attribute 'alt' of: <div><div><div><img><img>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:25 _includes/ai-contextualrag.html:26
 msgid "Contextual RAG query image"
-msgstr ""
+msgstr "コンテキストRAGクエリ画像"
 
 #. type: Content of: <div><div><div><img><img><h2>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:27
 msgid "Scalability & Performance"
-msgstr ""
+msgstr "スケーラビリティとパフォーマンス"
 
 #. type: Content of: <div><div><div><img><img><p>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:28
 msgid "Efficiently scaling and optimizing the performance of your AI solutions are crucial for enterprise adoption and operational success. While this blueprint only gives you some high level guidance, we strongly recommend to also look into the non functional aspects of your solution and ways to address these concepts:"
-msgstr ""
+msgstr "AIソリューションのスケーリングとパフォーマンスの最適化を効率的に行うことは、企業での採用と運用上の成功にとって不可欠です。この設計図は高レベルのガイダンスを提供するに過ぎませんが、ソリューションの非機能要件と、これらの概念に対処する方法も検討することを強く推奨します:"
 
 #. type: Content of: <div><div><div><img><img><ul><li>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:30
 msgid "<strong>Domain/Tenant Sharding:</strong> Retrieves information based on semantic similarity from a vector store."
-msgstr ""
+msgstr "<strong>ドメイン/テナントシャーディング:</strong> ベクトルストアからセマンティックな類似性に基づいて情報を検索します。"
 
 #. type: Content of: <div><div><div><img><img><ul><li>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:31
 msgid "<strong>Caching:</strong> Cache query vectors and top-K hits for improved performance."
-msgstr ""
+msgstr "<strong>キャッシュ:</strong> パフォーマンス向上のために、クエリベクトルとトップKヒットをキャッシュします。"
 
 #. type: Content of: <div><div><div><img><img><ul><li>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:32
 msgid "<strong>Asynchronous Ingestion:</strong> Utilize asynchronous ingestion to batch embeddings and stream deltas."
-msgstr ""
+msgstr "<strong>非同期取り込み:</strong> 非同期取り込みを活用して、埋め込みをバッチ処理し、デルタをストリームします。"
 
 #. type: Content of: <div><div><div><img><img><ul><li>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:33
 msgid "<strong>Lean Prompts:</strong> Prioritize token budget for context, keeping prompts concise."
-msgstr ""
+msgstr "<strong>リーンプロンプト:</strong> コンテキストのためのトークン予算を優先し、プロンプトを簡潔に保ちます。"
 
 #. type: Content of: <div><div><div><img><img><h2>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:35
 msgid "Security"
-msgstr ""
+msgstr "セキュリティー"
 
 #. type: Content of: <div><div><div><img><img><p>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:36
 msgid "Architecting secure enterprise AI solutions demands a proactive approach to safeguard sensitive data and preserve organizational integrity. Below are some first thoughts about critical security considerations and architectural patterns you should further investigate when building your solution."
-msgstr ""
+msgstr "セキュアな企業AIソリューションを設計することは、機密データを保護し、組織の完全性を維持するためにプロアクティブなアプローチを求められます。以下は、ソリューションを構築する際にさらに調査すべき、重要なセキュリティーの考慮事項とアーキテクチャパターンに関する最初の考察です。"
 
 #. type: Content of: <div><div><div><img><img><ul><li>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:38
 msgid "<strong>Authorization at retrieval:</strong> Before injecting context, filter by user/tenant claims."
-msgstr ""
+msgstr "<strong>検索時の認可:</strong> コンテキストを注入する前に、ユーザー/テナントのクレームでフィルタリングします。"
 
 #. type: Content of: <div><div><div><img><img><ul><li>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:39
 msgid "<strong>Audit lineage:</strong> Store the chunk→document→source linkage with timestamps."
-msgstr ""
+msgstr "<strong>監査系譜:</strong> チャンク→ドキュメント→ソースの連携をタイムスタンプと共に保存します。"
 
 #. type: Content of: <div><div><div><img><img><ul><li>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:40
 msgid "<strong>PII controls:</strong> Redact or mask sensitive spans before embedding and prompting."
-msgstr ""
+msgstr "<strong>PII制御:</strong> 埋め込みとプロンプトの前に、機密性の高いスパンを編集またはマスクします。"
 
 #. type: Content of: <div><div><div><img><img><ul><li>
+#. mt: gemini
 #: _includes/ai-contextualrag.html:41
 msgid "<strong>Guard responses:</strong> Post-filter for data leakage and policy violations."
-msgstr ""
+msgstr "<strong>応答の保護:</strong> データ漏洩やポリシー違反がないか事後的にフィルタリングします。"

--- a/l10n/po/ja_JP/_includes/ai-frozenrag.html.po
+++ b/l10n/po/ja_JP/_includes/ai-frozenrag.html.po
@@ -10,126 +10,151 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Content of: <div><div><div><h1>
+#. mt: gemini
 #: _includes/ai-frozenrag.html:5
 msgid "Frozen RAG (Retrieval-Augmented Generation)"
-msgstr ""
+msgstr "Frozen RAG (検索拡張生成)"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-frozenrag.html:6
 msgid "Integrate RAG to anchor Large Language Model (LLM) responses in your enterprise data, with Quarkus handling ingestion pipelines, query execution, embedding generation, context retrieval, and seamless LLM interaction. This blueprint focuses on the foundational RAG pattern (also called frozen RAG); more advanced contextual RAG variants, including multi-source routing and reranking, are covered separately."
-msgstr ""
+msgstr "RAGを統合して、大規模言語モデル (LLM) の応答を企業データに固定します。Quarkusは、取り込みパイプライン、クエリ実行、埋め込み生成、コンテキスト取得、シームレスなLLM連携を処理します。このブループリントは、基本的なRAGパターン（Frozen RAGとも呼ばれる）に焦点を当てています。マルチソースルーティングや再ランキングを含む、より高度なコンテキストRAGのバリアントについては別途説明します。"
 
 #. type: Content of: <div><div><div><h2>
+#. mt: gemini
 #: _includes/ai-frozenrag.html:7
 msgid "Main Use-Cases"
-msgstr ""
+msgstr "主なユースケース"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-frozenrag.html:9
 msgid "<strong>Reduced Hallucinations:</strong> RAG ensures that LLM answers are explicitly tied to enterprise-specific sources such as policies, manuals, or knowledge bases. This grounding reduces the risk of fabricated or misleading responses and increases trust in AI-assisted decision-making."
-msgstr ""
+msgstr "<strong>ハルシネーションの削減:</strong> RAGは、LLMの回答がポリシー、マニュアル、ナレッジベースなどの企業固有のソースに明示的に結び付けられるようにします。この根拠付けにより、捏造されたり誤解を招くような回答のリスクが減り、AIを活用した意思決定への信頼が高まります。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-frozenrag.html:10
 msgid "<strong>Up-to-Date Information:</strong> Because the retrieval step pulls directly from current document repositories and databases, responses adapt automatically as content evolves. There is no need to retrain or fine-tune the underlying model whenever business data changes."
-msgstr ""
+msgstr "<strong>最新の情報:</strong> 取得ステップが現在のドキュメントリポジトリとデータベースから直接情報を引き出すため、コンテンツの進化に合わせて応答が自動的に適応します。ビジネスデータが変更されるたびに、基盤となるモデルを再トレーニングしたり、ファインチューニングしたりする必要はありません。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-frozenrag.html:11
 msgid "<strong>Cost Efficiency:</strong> By retrieving only the most relevant context chunks, prompts stay concise. This reduces token usage in LLM calls, which directly lowers cost while preserving accuracy and completeness."
-msgstr ""
+msgstr "<strong>コスト効率:</strong> 最も関連性の高いコンテキストチャンクのみを取得することで、プロンプトは簡潔に保たれます。これにより、LLM呼び出しでのトークン使用量が削減され、精度と完全性を維持しながらコストを直接削減できます。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-frozenrag.html:12
 msgid "<strong>Java-Native Enterprise Integration:</strong> Quarkus provides a first-class runtime for embedding RAG workflows into existing enterprise systems. Developers can secure RAG services with OIDC or LDAP, expose them through familiar REST or Kafka APIs, and monitor them with Prometheus and OpenTelemetry. Because RAG runs inside the same application fabric as other Java services, it fits naturally into existing authentication, authorization, deployment, and observability workflows. This ensures AI augmentation is not just added, but part of the enterprise architecture."
-msgstr ""
+msgstr "<strong>Javaネイティブなエンタープライズ統合:</strong> Quarkusは、既存のエンタープライズシステムにRAGワークフローを組み込むためのファーストクラスのランタイムを提供します。開発者は、OIDCやLDAPでRAGサービスを保護し、使い慣れたRESTまたはKafka APIを通じて公開し、PrometheusやOpenTelemetryで監視できます。RAGは他のJavaサービスと同じアプリケーションファブリック内で実行されるため、既存の認証、認可、デプロイメント、および可観測性ワークフローに自然に適合します。これにより、AIオーグメンテーションが単に追加されるだけでなく、エンタープライズアーキテクチャの一部となります。"
 
 #. type: Content of: <div><div><div><h2>
+#. mt: gemini
 #: _includes/ai-frozenrag.html:14
 msgid "Architecture Overview"
-msgstr ""
+msgstr "アーキテクチャ概要"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-frozenrag.html:15
 msgid "Contextual RAG focuses on integrating Retrieval-Augmented Generation (RAG) to ground Large Language Model (LLM) responses in organizational data."
-msgstr ""
+msgstr "コンテキストRAGは、検索拡張生成（RAG）を統合して、大規模言語モデル（LLM）の応答を組織データに基づかせることに焦点を当てています。"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-frozenrag.html:16
 msgid "The architecture is divided into two main phases:"
-msgstr ""
+msgstr "アーキテクチャは主に2つのフェーズに分かれています:"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-frozenrag.html:17
 msgid "<strong>Ingestion:</strong> This phase prepares enterprise knowledge for retrieval. In a frozen RAG setup, data typically originates from unstructured document sources such as manuals, PDFs, or reports."
-msgstr ""
+msgstr "<strong>取り込み (Ingestion):</strong> このフェーズでは、取得するための企業知識を準備します。Frozen RAGのセットアップでは、データは通常、マニュアル、PDF、レポートなどの非構造化ドキュメントソースから取得されます。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-frozenrag.html:19
 msgid "Documents are processed by a \"Text Splitter\" to break them into smaller chunks."
-msgstr ""
+msgstr "ドキュメントは「Text Splitter」によって処理され、より小さなチャンクに分割されます。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-frozenrag.html:20
 msgid "These chunks are then converted into numerical representations (embeddings) using an \"Embedding Model\"."
-msgstr ""
+msgstr "これらのチャンクは、「Embedding Model」を使用して数値表現（埋め込み）に変換されます。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-frozenrag.html:21
 msgid "The embeddings are stored in a \"Vector Store\" for semantic similarity searches."
-msgstr ""
+msgstr "埋め込みは、セマンティック類似性検索のために「Vector Store」に保存されます。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-frozenrag.html:22
 msgid "Metadata about the documents, such as lineage and other relevant information, is stored in a \"Metadata Store\"."
-msgstr ""
+msgstr "系譜やその他の関連情報など、ドキュメントに関するメタデータは「Metadata Store」に保存されます。"
 
 #. type: Attribute 'alt' of: <div><div><div><img><img>
+#. mt: gemini
 #: _includes/ai-frozenrag.html:24 _includes/ai-frozenrag.html:25
 msgid "Frozen RAG ingestion image"
-msgstr ""
+msgstr "Frozen RAG 取り込みイメージ"
 
 #. type: Content of: <div><div><div><img><img><p>
+#. mt: gemini
 #: _includes/ai-frozenrag.html:26
 msgid "<strong>Query:</strong> This phase handles user queries and generates grounded answers."
-msgstr ""
+msgstr "<strong>クエリ (Query):</strong> このフェーズでは、ユーザーのクエリを処理し、根拠のある回答を生成します。"
 
 #. type: Content of: <div><div><div><img><img><ul><li>
+#. mt: gemini
 #: _includes/ai-frozenrag.html:28
 msgid "A \"User Query\" is received and processed by a \"Query Embedding\" component to create an embedding of the query."
-msgstr ""
+msgstr "「User Query」が受信され、「Query Embedding」コンポーネントによって処理され、クエリの埋め込みが作成されます。"
 
 #. type: Content of: <div><div><div><img><img><ul><li>
+#. mt: gemini
 #: _includes/ai-frozenrag.html:29
 msgid "The query embedding is used in a \"Similarity Search\" against the \"Vector Store\" to retrieve relevant document chunks. The \"Vector Store\" \"serves\" the similarity search."
-msgstr ""
+msgstr "クエリの埋め込みは、「Vector Store」に対する「Similarity Search」で使用され、関連するドキュメントチャンクを取得します。「Vector Store」は類似性検索を「提供」します。"
 
 #. type: Content of: <div><div><div><img><img><ul><li>
+#. mt: gemini
 #: _includes/ai-frozenrag.html:30
 msgid "The retrieved chunks, along with metadata from the \"Metadata Store\" (which acts as the \"source of truth\"), are assembled into a \"Context Pack\"."
-msgstr ""
+msgstr "取得されたチャンクは、「Metadata Store」（「信頼できる情報源」として機能）からのメタデータとともに、「Context Pack」に組み立てられます。"
 
 #. type: Content of: <div><div><div><img><img><ul><li>
+#. mt: gemini
 #: _includes/ai-frozenrag.html:31
 msgid "The \"Context Pack\" is used by a \"Prompt Assembly\" component to construct an \"Enhanced Prompt\" that includes the relevant context."
-msgstr ""
+msgstr "「Context Pack」は、「Prompt Assembly」コンポーネントによって使用され、関連するコンテキストを含む「Enhanced Prompt」を構築します。"
 
 #. type: Content of: <div><div><div><img><img><ul><li>
+#. mt: gemini
 #: _includes/ai-frozenrag.html:32
 msgid "The \"Enhanced Prompt\" is fed into an \"LLM (LangChain4j)\"."
-msgstr ""
+msgstr "「Enhanced Prompt」は「LLM (LangChain4j)」にフィードされます。"
 
 #. type: Content of: <div><div><div><img><img><ul><li>
+#. mt: gemini
 #: _includes/ai-frozenrag.html:33
 msgid "The LLM generates a \"Grounded Answer\" based on the provided context."
-msgstr ""
+msgstr "LLMは、提供されたコンテキストに基づいて「Grounded Answer」を生成します。"
 
 #. type: Attribute 'alt' of: <div><div><div><img><img><img><img>
+#. mt: gemini
 #: _includes/ai-frozenrag.html:35 _includes/ai-frozenrag.html:36
 msgid "Frozen RAG query image"
-msgstr ""
+msgstr "Frozen RAG クエリイメージ"
 
 #. type: Content of: <div><div><div><img><img><img><img><p>
+#. mt: gemini
 #: _includes/ai-frozenrag.html:37
 msgid "This two-phase approach allows for reduced hallucinations in LLM responses, up-to-date information without retraining, cost efficiency by retrieving only relevant information, and seamless integration with existing enterprise Java services and workflows."
-msgstr ""
+msgstr "この2段階アプローチにより、LLM応答におけるハルシネーションの削減、再トレーニングなしでの最新情報の提供、関連情報のみを取得することによるコスト効率の向上、既存のエンタープライズJavaサービスおよびワークフローとのシームレスな統合が可能になります。"

--- a/l10n/po/ja_JP/_includes/ai-java-for-ai.html.po
+++ b/l10n/po/ja_JP/_includes/ai-java-for-ai.html.po
@@ -10,191 +10,229 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Attribute 'alt' of: <div><div><div><img>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:4
 msgid "Java for AI icon"
-msgstr ""
+msgstr "AI向けJavaアイコン"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:7
 msgid "Artificial Intelligence is reshaping enterprise software, and Java remains the backbone. Its long-standing reliability, security, and scalability make it ideal for building AI-infused applications."
-msgstr ""
+msgstr "人工知能はエンタープライズソフトウェアを再構築しており、Javaはその基盤であり続けています。その長年にわたる信頼性、セキュリティ、スケーラビリティは、AI搭載アプリケーションの構築に最適です。"
 
 #. type: Content of: <div><div><div><h2>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:11
 msgid "Java in Data Preparation"
-msgstr ""
+msgstr "データ準備におけるJava"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:12
 msgid "Many AI initiatives begin with robust data processing pipelines."
-msgstr ""
+msgstr "多くのAIイニシアチブは、堅牢なデータ処理パイプラインから始まります。"
 
 #. type: Content of: <div><div><div><h3>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:13
 msgid "Effective AI requires two distinct pipelines:"
-msgstr ""
+msgstr "効果的なAIには、2つの異なるパイプラインが必要です。"
 
 #. type: Content of: <div><div><div><dl><dt>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:17
 msgid "Training Data Preparation"
-msgstr ""
+msgstr "トレーニングデータの準備"
 
 #. type: Content of: <div><div><div><dl><dd>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:18
 msgid "Build predictive models with DeepLearning4J (DL4J). Java’s ecosystem, including Apache Kafka, Apache Flink, and Apache Camel, supports large-scale ETL, data cleansing, and preprocessing across enterprise data."
-msgstr ""
+msgstr "DeepLearning4J (DL4J) を使用して予測モデルを構築します。Apache Kafka、Apache Flink、Apache Camel を含む Java のエコシステムは、エンタープライズデータ全体における大規模な ETL、データクレンジング、前処理をサポートします。"
 
 #. type: Content of: <div><div><div><dl><dt>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:23
 msgid "RAG Data Preparation"
-msgstr ""
+msgstr "RAGデータ準備"
 
 #. type: Content of: <div><div><div><dl><dd>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:24
 msgid "For Retrieval-Augmented Generation, ingest documents and business knowledge, compute embeddings, and index in vector stores. Java seamlessly connects to databases, message brokers, and vector stores, enabling RAG pipelines that are both fast and reliable."
-msgstr ""
+msgstr "Retrieval-Augmented Generation の場合、ドキュメントとビジネス知識を取り込み、埋め込みを計算し、ベクトルストアにインデックスを作成します。Java はデータベース、メッセージブローカー、ベクトルストアにシームレスに接続し、高速かつ信頼性の高い RAG パイプラインを実現します。"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:28
 msgid "This dual capability, supporting both model training and RAG processes, makes Java uniquely powerful in AI architectures."
-msgstr ""
+msgstr "モデルトレーニングとRAGプロセスの両方をサポートするこの二重の機能により、JavaはAIアーキテクチャにおいて他に類を見ないほどの強力さを発揮します。"
 
 #. type: Content of: <div><div><div><h2>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:34
 msgid "Java for AI-Infused Applications and Intelligent Applications"
-msgstr ""
+msgstr "AI搭載アプリケーションとインテリジェントアプリケーション向けJava"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:35
 msgid "Once data and models are ready, enterprises need applications that:"
-msgstr ""
+msgstr "データとモデルの準備ができたら、企業は次のようなアプリケーションを必要とします。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:37
 msgid "Embed AI in customer-facing workflows (chatbots, fraud detection, document assistants)."
-msgstr ""
+msgstr "顧客向けのワークフロー（チャットボット、不正検出、ドキュメントアシスタント）にAIを組み込む。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:38
 msgid "Interact with predictive and generative AI models (in-process, locally or remotely)."
-msgstr ""
+msgstr "予測型AIモデルや生成型AIモデルと連携する（インプロセス、ローカル、またはリモートで）。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:39
 msgid "Scale from prototype to production on cloud or on-prem."
-msgstr ""
+msgstr "プロトタイプからクラウドまたはオンプレミスの本番環境へとスケールする。"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:41
 msgid "The JVM ecosystem ensures consistency, portability, and performance across deployments."
-msgstr ""
+msgstr "JVMエコシステムは、デプロイメント全体で一貫性、ポータビリティ、およびパフォーマンスを保証します。"
 
 #. type: Content of: <div><div><div><h2>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:45
 msgid "Enterprise-Grade Security, Governance & Observability"
-msgstr ""
+msgstr "エンタープライズグレードのセキュリティ、ガバナンス、Observability"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:46
 msgid "Java brings full enterprise readiness to AI systems:"
-msgstr ""
+msgstr "Javaは、AIシステムに完全なエンタープライズ対応性をもたらします。"
 
 #. type: Content of: <div><div><div><dl><dt>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:50
 msgid "Security by Design:"
-msgstr ""
+msgstr "設計によるセキュリティ:"
 
 #. type: Content of: <div><div><div><dl><dd>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:51
 msgid "Supports traceable inputs, audit trails, and governance-ready execution from day one."
-msgstr ""
+msgstr "トレース可能な入力、監査証跡、および最初からガバナンス対応の実行をサポートします。"
 
 #. type: Content of: <div><div><div><dl><dt>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:56
 msgid "Proven at Scale:"
-msgstr ""
+msgstr "大規模で実証済み:"
 
 #. type: Content of: <div><div><div><dl><dd>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:57
 msgid "Decades of enterprise deployment ensure predictable performance and long-term maintainability."
-msgstr ""
+msgstr "数十年にわたるエンタープライズデプロイメントにより、予測可能なパフォーマンスと長期的な保守性が保証されます。"
 
 #. type: Content of: <div><div><div><dl><dt>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:62
 msgid "Stable Innovation:"
-msgstr ""
+msgstr "安定したイノベーション:"
 
 #. type: Content of: <div><div><div><dl><dd>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:63
 msgid "Embraces modern tools like LangChain4j while preserving strong typing, backward compatibility, and developer familiarity."
-msgstr ""
+msgstr "LangChain4jのような最新ツールを取り入れつつ、強力な型付け、後方互換性、開発者の親しみやすさを維持します。"
 
 #. type: Content of: <div><div><div><dl><dt>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:68
 msgid "Observability:"
-msgstr ""
+msgstr "Observability:"
 
 #. type: Content of: <div><div><div><dl><dd>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:69
 msgid "Java applications, especially those built with Quarkus, incorporate metrics, tracing, and logs, thereby improving operational tasks. This unified telemetry enables real-time monitoring of AI pipelines and live troubleshooting."
-msgstr ""
+msgstr "Javaアプリケーション、特にQuarkusで構築されたものは、メトリクス、トレース、ログを組み込み、運用タスクを改善します。この統合されたテレメトリにより、AIパイプラインのリアルタイム監視とライブトラブルシューティングが可能になります。"
 
 #. type: Content of: <div><div><div><h2>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:74
 msgid "Java & Emerging AI Protocols"
-msgstr ""
+msgstr "Javaと新しいAIプロトコル"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:75
 msgid "The Java ecosystem has long been foundational for interoperability."
-msgstr ""
+msgstr "Javaエコシステムは、長年にわたり相互運用性の基盤となってきました。"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:76
 msgid "So, it’s not surprising to see Java client and server implementations for the emerging AI protocols, such as:"
-msgstr ""
+msgstr "したがって、次のような新しいAIプロトコル向けのJavaクライアントおよびサーバーの実装が見られることは驚くべきことではありません。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:78
 msgid "<strong>MCP (Model context Protocol):</strong> Enables building servers and clients that integrate LLMs with enterprise systems."
-msgstr ""
+msgstr "<strong>MCP (Model context Protocol):</strong> LLMをエンタープライズシステムと統合するサーバーおよびクライアントの構築を可能にします。"
 
 #. type: Content of: <div><div><div><ul><li>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:79
 msgid "<strong>A2A (Agent-to-Agent):</strong> Supports reliable autonomous agent communication across ecosystems."
-msgstr ""
+msgstr "<strong>A2A (Agent-to-Agent):</strong> エコシステム全体で信頼性の高い自律エージェント通信をサポートします。"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:81
 msgid "Java’s mature networking and concurrency capabilities make it ideal for implementing these agentic, AI-driven architectures."
-msgstr ""
+msgstr "Javaの成熟したネットワーキングと並行処理機能は、これらのエージェント的なAI駆動型アーキテクチャを実装するのに最適です。"
 
 #. type: Content of: <div><div><div><h2>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:85
 msgid "Dive into using Java and AI"
-msgstr ""
+msgstr "JavaとAIの活用を深掘りする"
 
 #. type: Content of: <div><div><div><div><div><p>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:88
 msgid "For Java enterprise developers and architects looking to expand their skill set into artificial intelligence and machine learning (AI/ML), getting started can feel intimidating, especially when faced with complex theory, data science, and unfamiliar programming languages."
-msgstr ""
+msgstr "人工知能と機械学習（AI/ML）にスキルセットを広げたいと考えているJavaエンタープライズ開発者やアーキテクトにとって、特に複雑な理論、データサイエンス、不慣れなプログラミング言語に直面すると、始めるのが難しく感じられるかもしれません。"
 
 #. type: Content of: <div><div><div><div><div><p>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:89
 msgid "Check out \"Applied AI for Enterprise Java Development\" by Alex Soto Bueno, Markus Eisele, and Natale Vinto. It's a practical guide which shows you how to integrate generative AI, large language models, and machine learning into your existing Java enterprise ecosystem, using tools and frameworks you already know and love."
-msgstr ""
+msgstr "Alex Soto Bueno、Markus Eisele、Natale Vintoによる「Applied AI for Enterprise Java Development」をご覧ください。これは、生成AI、大規模言語モデル、機械学習を、すでに知っていて気に入っているツールやフレームワークを使用して、既存のJavaエンタープライズエコシステムに統合する方法を示す実践的なガイドです。"
 
 #. type: Content of: <div><div><div><div><div><p>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:90
 msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"https://developers.redhat.com/e-books/applied-ai-enterprise-java-development\">Download the free ebook now!</a>"
-msgstr ""
+msgstr "<i class=\"fa fa-chevron-right\"></i><a href=\"https://developers.redhat.com/e-books/applied-ai-enterprise-java-development\">無料の電子書籍を今すぐダウンロード！</a>"
 
 #. type: Content of: <div><div><div><div><div><a>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:93
 msgid "<a href=\"https://developers.redhat.com/e-books/applied-ai-enterprise-java-development\" alt=\"Applied AI for Enterprise Java Development link\">"
-msgstr ""
+msgstr "<a href=\"https://developers.redhat.com/e-books/applied-ai-enterprise-java-development\" alt=\"エンタープライズJava開発のための応用AIへのリンク\">"
 
 #. type: Attribute 'alt' of: <div><div><div><div><div><a><img>
+#. mt: gemini
 #: _includes/ai-java-for-ai.html:93
 msgid "Applied AI for Enterprise Java Development image"
-msgstr ""
+msgstr "エンタープライズJava開発のための応用AIの画像"

--- a/l10n/po/ja_JP/_includes/ai-overview.html.po
+++ b/l10n/po/ja_JP/_includes/ai-overview.html.po
@@ -10,121 +10,145 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Attribute 'alt' of: <div><div><div><img>
+#. mt: gemini
 #: _includes/ai-overview.html:4
 msgid "Java for AI icon"
-msgstr ""
+msgstr "AI向けJavaアイコン"
 
 #. type: Content of: <div><div><div><h2>
+#. mt: gemini
 #: _includes/ai-overview.html:7
 msgid "Why use Java for AI?"
-msgstr ""
+msgstr "AIにJavaを使用する理由"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-overview.html:8
 msgid "Java is ideal for AI development due to its platform independence, robust memory management, and rich open-source libraries like Deeplearning4j, Weka, and Apache Spark. Its mature ecosystem and strong community support enable scalable AI applications. With recent JVM optimizations, Java's performance handles demanding machine learning tasks and large datasets efficiently."
-msgstr ""
+msgstr "Javaは、そのプラットフォーム独立性、堅牢なメモリー管理、そしてDeeplearning4j、Weka、Apache Sparkのような豊富なオープンソースライブラリにより、AI開発に理想的です。成熟したエコシステムと強力なコミュニティサポートにより、スケーラブルなAIアプリケーションを可能にします。最近のJVM最適化により、Javaのパフォーマンスは要求の厳しい機械学習タスクと大規模なデータセットを効率的に処理します。"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-overview.html:9
 msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/java-for-ai\">Learn more about using Java for AI</a>"
-msgstr ""
+msgstr "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/java-for-ai\">AIにJavaを使用することについて詳しく学ぶ</a>"
 
 #. type: Content of: <div><div><div><h2>
+#. mt: gemini
 #: _includes/ai-overview.html:13
 msgid "Why use Quarkus for AI-Infused Applications"
-msgstr ""
+msgstr "AI搭載アプリケーションにQuarkusを使用する理由"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-overview.html:14
 msgid "Quarkus is ideal for AI applications due to its performance, agility, and developer experience. It offers native Generative AI integration via LangChain4j, supporting declarative AI services, various LLMs, and advanced prompt engineering. It also handles predictive AI and data pipeline automation with ML toolkits for scalable ETL and embedding workflows. Quarkus's \"AI-Enhanced Developer Experience\" provides fast startups, low memory, and a reactive core for cloud-native AI. It boosts developer velocity with live coding, a unified Java stack, and robust observability/security for reliable AI services."
-msgstr ""
+msgstr "Quarkusは、そのパフォーマンス、俊敏性、開発エクスペリエンスにより、AIアプリケーションに理想的です。LangChain4jを介したネイティブな生成AI統合を提供し、宣言型AIサービス、多様なLLM、および高度なプロンプトエンジニアリングをサポートします。また、スケーラブルなETLおよび埋め込みワークフローのためのMLツールキットを使用して、予測AIとデータパイプラインの自動化も処理します。Quarkusの「AI強化開発エクスペリエンス」は、高速起動、低メモリー使用量、クラウドネイティブAIのためのリアクティブコアを提供します。ライブコーディング、統一されたJavaスタック、堅牢な可観測性/セキュリティにより、信頼性の高いAIサービスのための開発者の速度を向上させます。"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-overview.html:15
 msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/quarkus-for-ai\">Learn more about using Quarkus for AI</a>"
-msgstr ""
+msgstr "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/quarkus-for-ai\">AIにQuarkusを使用することについて詳しく学ぶ</a>"
 
 #. type: Content of: <div><div><div><h3>
+#. mt: gemini
 #: _includes/ai-overview.html:19
 msgid "Benefits of Quarkus for AI-Infused Applications"
-msgstr ""
+msgstr "AI搭載アプリケーション向けQuarkusの利点"
 
 #. type: Attribute 'alt' of: <div><div><div><img><img>
+#. mt: gemini
 #: _includes/ai-overview.html:22 _includes/ai-overview.html:23
 msgid "Native Integration with Generative AI icon"
-msgstr ""
+msgstr "生成AIとのネイティブ統合アイコン"
 
 #. type: Content of: <div><div><div><img><img><h4>
+#. mt: gemini
 #: _includes/ai-overview.html:24
 msgid "Native Integration with Generative AI"
-msgstr ""
+msgstr "生成AIとのネイティブ統合"
 
 #. type: Content of: <div><div><div><img><img><p>
+#. mt: gemini
 #: _includes/ai-overview.html:25
 msgid "Easily build AI workflows with minimal code, leveraging top LLM providers to create features like chatbots and summarizers."
-msgstr ""
+msgstr "最小限のコードでAIワークフローを簡単に構築し、主要なLLMプロバイダーを活用してチャットボットや要約機能などの機能を作成します。"
 
 #. type: Attribute 'alt' of: <div><div><div><img><img>
+#. mt: gemini
 #: _includes/ai-overview.html:28 _includes/ai-overview.html:29
 msgid "Predictive AI and Data Pipelines icon"
-msgstr ""
+msgstr "予測AIとデータパイプラインアイコン"
 
 #. type: Content of: <div><div><div><img><img><h4>
+#. mt: gemini
 #: _includes/ai-overview.html:30
 msgid "Predictive AI and Data Pipelines"
-msgstr ""
+msgstr "予測AIとデータパイプライン"
 
 #. type: Content of: <div><div><div><img><img><p>
+#. mt: gemini
 #: _includes/ai-overview.html:31
 msgid "Enable predictive AI, model training, and scalable data workflows, connecting seamlessly to ML tools, message brokers, databases, and files."
-msgstr ""
+msgstr "予測AI、モデルトレーニング、スケーラブルなデータワークフローを可能にし、MLツール、メッセージブローカー、データベース、ファイルにシームレスに接続します。"
 
 #. type: Attribute 'alt' of: <div><div><div><img><img>
+#. mt: gemini
 #: _includes/ai-overview.html:34 _includes/ai-overview.html:35
 msgid "Enhanced Developer Experience icon"
-msgstr ""
+msgstr "強化された開発エクスペリエンスアイコン"
 
 #. type: Content of: <div><div><div><img><img><h4>
+#. mt: gemini
 #: _includes/ai-overview.html:36
 msgid "Enhanced Developer Experience"
-msgstr ""
+msgstr "強化された開発エクスペリエンス"
 
 #. type: Content of: <div><div><div><img><img><p>
+#. mt: gemini
 #: _includes/ai-overview.html:37
 msgid "Incorporate AI directly into development workflow with instant feedback, code explanations, and documentation, speeding up iterations."
-msgstr ""
+msgstr "即座のフィードバック、コードの説明、ドキュメントを活用してAIを開発ワークフローに直接組み込み、反復作業を迅速化します。"
 
 #. type: Attribute 'alt' of: <div><div><div><img><img>
+#. mt: gemini
 #: _includes/ai-overview.html:40 _includes/ai-overview.html:41
 msgid "Enterprise-Grade icon"
-msgstr ""
+msgstr "エンタープライズグレードアイコン"
 
 #. type: Content of: <div><div><div><img><img><h4>
+#. mt: gemini
 #: _includes/ai-overview.html:42
 msgid "Enterprise-Grade AI"
-msgstr ""
+msgstr "エンタープライズグレードAI"
 
 #. type: Content of: <div><div><div><img><img><p>
+#. mt: gemini
 #: _includes/ai-overview.html:43
 msgid "Create reliable, secure AI applications using Quarkus’s built-in observability, security, and governance—ensuring AI services are safe, accountable, and performance-ready from the beginning."
-msgstr ""
+msgstr "Quarkusの組み込みの可観測性、セキュリティ、ガバナンスを活用して、信頼性と安全性の高いAIアプリケーションを構築します。これにより、AIサービスが最初から安全で、説明責任を果たし、パフォーマンスに対応できるようにします。"
 
 #. type: Attribute 'alt' of: <div><div><div><img><img>
+#. mt: gemini
 #: _includes/ai-overview.html:49 _includes/ai-overview.html:50
 msgid "AI blueprints icon"
-msgstr ""
+msgstr "AIブループリントアイコン"
 
 #. type: Content of: <div><div><div><h2>
+#. mt: gemini
 #: _includes/ai-overview.html:53
 msgid "Enterprise AI Blueprints for Java with Quarkus & LangChain4j"
-msgstr ""
+msgstr "Quarkus & LangChain4jを使用したJava向けエンタープライズAIブループリント"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-overview.html:54
 msgid "AI blueprints offer conceptual, infrastructure-agnostic reference architectures for developing enterprise-grade AI solutions in Java. They simplify AI integration in Java applications, guiding software architects in building intelligent chatbots, recommendation engines, and data analysis tools. These blueprints, leveraging Quarkus and LangChain4j, provide a solid starting point for advanced AI capabilities in your Java projects."
-msgstr ""
+msgstr "AIブループリントは、JavaでエンタープライズグレードのAIソリューションを開発するための、概念的でインフラに依存しない参照アーキテクチャーを提供します。これらはJavaアプリケーションにおけるAI統合を簡素化し、ソフトウェアアーキテクトがインテリジェントなチャットボット、レコメンデーションエンジン、データ分析ツールを構築する際の指針となります。QuarkusとLangChain4jを活用したこれらのブループリントは、Javaプロジェクトにおける高度なAI機能の堅固な出発点となります。"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/ai-overview.html:55
 msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/ai-blueprints\">Learn more about using Quarkus for AI</a>"
-msgstr ""
+msgstr "<i class=\"fa fa-chevron-right\"></i><a href=\"{{site.baseurl}}/ai-blueprints\">AIにQuarkusを使用することについて詳しく学ぶ</a>"

--- a/l10n/po/ja_JP/_includes/homepage-commonhaus-band.html.po
+++ b/l10n/po/ja_JP/_includes/homepage-commonhaus-band.html.po
@@ -10,26 +10,31 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Content of: <div><div><div><a>
+#. mt: gemini
 #: _includes/homepage-commonhaus-band.html:4
 msgid "<a href=\"https://www.commonhaus.org/\">"
-msgstr ""
+msgstr "<a href=\"https://www.commonhaus.org/\">"
 
 #. type: Attribute 'alt' of: <div><div><div><a><img><img>
+#. mt: gemini
 #: _includes/homepage-commonhaus-band.html:4
 msgid "Quarkus is part of the Commonhaus Foundation."
-msgstr ""
+msgstr "QuarkusはCommonhaus Foundationの一部です。"
 
 #. type: Content of: <div><div><div><h2>
+#. mt: gemini
 #: _includes/homepage-commonhaus-band.html:7
 msgid "Quarkus is part of the Commonhaus Foundation"
-msgstr ""
+msgstr "QuarkusはCommonhaus Foundationの一部です"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/homepage-commonhaus-band.html:8
 msgid "In order to fulfill our goal of being a more inclusive and fostering a more collaborative environment, we have moved to the Commonhaus Foundation. This is a step to further solidify our commitment to open-source development and enterprise adoption, addressing the perception that it was overly dependent on a single vendor (Red Hat). This move aims to provide a neutral ground where other organizations and contributors can feel equally valued and involved, ensuring Quarkus continues to thrive, supported by a broad base of contributors from multiple organizations."
-msgstr ""
+msgstr "より包括的で協調的な環境を育むという目標を達成するため、私たちはCommonhaus Foundationへ移行しました。これは、オープンソース開発とエンタープライズでの採用へのコミットメントをさらに強固にするためのステップであり、特定のベンダー (Red Hat) に過度に依存しているという認識に対処するものです。この移行は、他の組織や貢献者が等しく評価され、関与できる中立的な場を提供し、複数の組織からの幅広い貢献者に支えられながらQuarkusが繁栄し続けることを目指しています。"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/homepage-commonhaus-band.html:9
 msgid "<i class=\"fa fa-chevron-right\"></i><a href=\"https://www.commonhaus.org/\">Learn more about Commonhaus Foundation.</a>"
-msgstr ""
+msgstr "<i class=\"fa fa-chevron-right\"></i><a href=\"https://www.commonhaus.org/\">Commonhaus Foundationについて詳しくはこちら。</a>"

--- a/l10n/po/ja_JP/_includes/newsletter-band.html.po
+++ b/l10n/po/ja_JP/_includes/newsletter-band.html.po
@@ -10,31 +10,37 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Content of: <div><div><div><h3>
+#. mt: gemini
 #: _includes/newsletter-band.html:4
 msgid "{{ site.data.newsletter.headline }}"
-msgstr ""
+msgstr "{{ site.data.newsletter.headline }}"
 
 #. type: Content of: <div><div>
+#. mt: gemini
 #: _includes/newsletter-band.html:7
 msgid "{% for item in site.data.newsletter.newsletter %}"
-msgstr ""
+msgstr "{% for item in site.data.newsletter.newsletter %}"
 
 #. type: Content of: <div><div><div>
+#. mt: gemini
 #: _includes/newsletter-band.html:9
 msgid "<a href=\"{{ item.link }}\"></a>"
-msgstr ""
+msgstr "<a href=\"{{ item.link }}\"></a>"
 
 #. type: Content of: <div><div><div><div><p>
+#. mt: gemini
 #: _includes/newsletter-band.html:11
 msgid "{{ item.title }}"
-msgstr ""
+msgstr "{{ item.title }}"
 
 #. type: Content of: <div><div><div><div><div>
+#. mt: gemini
 #: _includes/newsletter-band.html:12
 msgid "Publication Date: {{ item.date }}"
-msgstr ""
+msgstr "公開日: {{ item.date }}"
 
 #. type: Content of: <div><div>
+#. mt: gemini
 #: _includes/newsletter-band.html:15
 msgid "{% endfor %}"
-msgstr ""
+msgstr "{% endfor %}"

--- a/l10n/po/ja_JP/_includes/training-band.html.po
+++ b/l10n/po/ja_JP/_includes/training-band.html.po
@@ -10,51 +10,61 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Content of: <div><div><div><h3>
+#. mt: gemini
 #: _includes/training-band.html:4
 msgid "{{ site.data.training.headline }}"
-msgstr ""
+msgstr "{{ site.data.training.headline }}"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/training-band.html:5
 msgid "{{ site.data.training.disclaimer }}"
-msgstr ""
+msgstr "{{ site.data.training.disclaimer }}"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/training-band.html:6
 msgid "{{ site.data.training.addtraining }}"
-msgstr ""
+msgstr "{{ site.data.training.addtraining }}"
 
 #. type: Content of: <div><div>
+#. mt: gemini
 #: _includes/training-band.html:9
 msgid "{% for item in site.data.training.courses %}"
-msgstr ""
+msgstr "{% for item in site.data.training.courses %}"
 
 #. type: Content of: <div><div><div>
+#. mt: gemini
 #: _includes/training-band.html:11
 msgid "<a href=\"{{item.url}}\" target=\"blank\"></a>"
-msgstr ""
+msgstr "<a href=\"{{item.url}}\" target=\"blank\"></a>"
 
 #. type: Content of: <div><div><div><p>
+#. mt: gemini
 #: _includes/training-band.html:12
 msgid "{{ item.affiliation }}"
-msgstr ""
+msgstr "{{ item.affiliation }}"
 
 #. type: Content of: <div><div><div><div>
+#. mt: gemini
 #: _includes/training-band.html:14
 msgid "{{ item.descr }}"
-msgstr ""
+msgstr "{{ item.descr }}"
 
 #. type: Content of: <div><div><div><div>
+#. mt: gemini
 #: _includes/training-band.html:17
 msgid "Course Type: {{ item.type }}"
-msgstr ""
+msgstr "コースタイプ: {{ item.type }}"
 
 #. type: Content of: <div><div><div><div>
+#. mt: gemini
 #: _includes/training-band.html:18
 msgid "Course Language: {{ item.language }}"
-msgstr ""
+msgstr "コース言語: {{ item.language }}"
 
 #. type: Content of: <div><div>
+#. mt: gemini
 #: _includes/training-band.html:21
 msgid "{% endfor %}"
-msgstr ""
+msgstr "{% endfor %}"


### PR DESCRIPTION
## Summary

Machine-translated 10 new HTML include files that were added in PR #1237.

## Translated Files

### AI-related content (7 files):
- `ai-blueprints.html.po` - AI blueprints content
- `ai-chainofthought.html.po` - AI chain of thought pattern
- `ai-contextualrag.html.po` - AI contextual RAG pattern
- `ai-frozenrag.html.po` - AI frozen RAG pattern
- `ai-java-for-ai.html.po` - Java for AI content
- `ai-overview.html.po` - AI overview content

### Site infrastructure (3 files):
- `CF-footerband.html.po` - Commonhaus Foundation footer
- `homepage-commonhaus-band.html.po` - Commonhaus homepage band
- `newsletter-band.html.po` - Newsletter subscription band
- `training-band.html.po` - Training resources band

## Translation Process

1. `tsuji po machine-translate --no-isAsciidoc` (HTML mode)
2. `tsuji po unfuzzy` (remove fuzzy flags)

## Notes

- Used `--no-isAsciidoc` flag for HTML content translation
- All files processed with DeepL API via tsuji
- Fuzzy flags removed after translation