### PR TITLE
Reduce fetch-depth from 0 to 50 in build and sync workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 50
           submodules: recursive
 
       - name: Set up JDK 21

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,9 +13,11 @@ jobs:
       - name: Checkout base branch
         uses: actions/checkout@v6
         with:
-          submodules: recursive
-          fetch-depth: 5000
+          fetch-depth: 50
           fetch-tags: false
+
+      - name: Fetch upstream submodule with deep history
+        run: git submodule update --init --depth 5000 upstream
 
       - name: Checkout merged commit to 'merged' dir
         uses: actions/checkout@v6

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 50
           submodules: recursive
 
       - name: Set up JDK 21


### PR DESCRIPTION
## Summary
- Reduce `fetch-depth` from `0` to `50` in build and sync workflows
- In pull-request workflow, split checkout and submodule init so the main repo uses `fetch-depth: 50` while the upstream submodule retains depth 5000 (needed for `git-restore-mtime`)
- The `.git` directory is 5.1GB mostly due to TMX file history (17MB file x 1,860 commits); reducing fetch depth avoids downloading the full history on every CI run