### PR TITLE
Fix incorrect repository URL in override stats issue body

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
             if grep -q "NG" l10n/stats/override.csv; then
               gh issue create \
                 --title "Corresponding files of those in the override directory are updated" \
-                --body "Corresponding files of those in the override directory are updated. see [override stats](https://github.com/doc-l10n-kit/ja.quarkus.io/blob/main/l10n/stats/override.csv) for more details."
+                --body "Corresponding files of those in the override directory are updated. see [override stats](https://github.com/quarkusio/ja.quarkus.io/blob/main/l10n/stats/override.csv) for more details."
             fi
           fi
 


### PR DESCRIPTION
## Summary
- Fix `doc-l10n-kit/ja.quarkus.io` → `quarkusio/ja.quarkus.io` in the issue body created by the build workflow