### PR TITLE
Remove stale HTML entries from extract include list

### DIFF
--- a/config/application.yaml
+++ b/config/application.yaml
@@ -75,7 +75,6 @@ tsuji:
           - _includes/get-started-band-lightblue.html
           - _includes/get-started-code-steps.html
           - _includes/header-navigation.html
-          - _includes/header-navigation_full.html
           - _includes/homepage-commonhaus-band.html
           - _includes/homepage-container_first-band.html
           - _includes/homepage-developer_joy-band.html
@@ -84,7 +83,6 @@ tsuji:
           - _includes/homepage-features-icon-band.html
           - _includes/homepage-hero-band.html
           - _includes/homepage-hero-band-ssjprime.html
-          - _includes/homepage-hero-Q2release-band.html
           - _includes/homepage-hero-newrelease-band.html
           - _includes/homepage-imperative_and_reactive-band.html
           - _includes/homepage-performance-band.html

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -58,18 +58,14 @@ tsuji:
           - _includes/ai-java-for-ai.html
           - _includes/ai-overview.html
           # - _includes/ai-quarkus-for-ai.html  # Temporarily excluded due to malformed HTML (upstream issue)
-          - _includes/awards-band.html
           # - _includes/benefactors.html  # Temporarily excluded due to malformed HTML (upstream issue)
           - _includes/catalog-detail-band.html
           - _includes/catalog-index-band.html
           - _includes/CF-footerband.html
-          - _includes/community-contrib-band.html
           - _includes/container-first.html
-          - _includes/continuum.html
           - _includes/developer-joy.html
           # - _includes/discussion.html  # Temporarily excluded due to malformed HTML (upstream issue)
           - _includes/events-discussions-band.html
-          - _includes/events-worldtour-band.html
           - _includes/feedback-community-band.html
           - _includes/get-started-band.html
           - _includes/get-started-band-lightblue.html


### PR DESCRIPTION
## Summary
- Remove some .html files from the HTML include list, as they no longer exist in upstream