### PR TITLE
Batch pushes in sync workflow

### DIFF
--- a/.github/actions/commit-changes/action.yml
+++ b/.github/actions/commit-changes/action.yml
@@ -1,0 +1,25 @@
+name: 'Commit Changes'
+description: 'Commits changes in l10n and upstream directories without pushing'
+inputs:
+  message:
+    description: 'Commit message'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Commit
+      shell: bash
+      run: |
+        GIT_USER_NAME=$(./tsujiw config get tsuji.git.user.name)
+        GIT_USER_EMAIL=$(./tsujiw config get tsuji.git.user.email)
+
+        git add upstream l10n
+
+        # Check if there are staged changes
+        if ! git diff --cached --exit-code --quiet; then
+          git config user.name "$GIT_USER_NAME"
+          git config user.email "$GIT_USER_EMAIL"
+          git commit -m "${{ inputs.message }}"
+        else
+          echo "No changes to commit"
+        fi

--- a/.github/actions/push-changes/action.yml
+++ b/.github/actions/push-changes/action.yml
@@ -1,17 +1,8 @@
 name: 'Push Changes'
-description: 'Commits and pushes changes in l10n and upstream directories'
-inputs:
-  message:
-    description: 'Commit message'
-    required: true
+description: 'Pushes local commits to origin/main'
 runs:
   using: "composite"
   steps:
-    - name: Commit
-      uses: ./.github/actions/commit-changes
-      with:
-        message: ${{ inputs.message }}
-
     - name: Push
       shell: bash
       run: |

--- a/.github/actions/push-changes/action.yml
+++ b/.github/actions/push-changes/action.yml
@@ -7,22 +7,14 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Commit and Push
+    - name: Commit
+      uses: ./.github/actions/commit-changes
+      with:
+        message: ${{ inputs.message }}
+
+    - name: Push
       shell: bash
       run: |
-        GIT_USER_NAME=$(./tsujiw config get tsuji.git.user.name)
-        GIT_USER_EMAIL=$(./tsujiw config get tsuji.git.user.email)
-        
-        git add upstream l10n
-        
-        # Check if there are staged changes
-        if ! git diff --cached --exit-code --quiet; then
-          git config user.name "$GIT_USER_NAME"
-          git config user.email "$GIT_USER_EMAIL"
-          git commit -m "${{ inputs.message }}"
-          git fetch origin main
-          git rebase origin/main
-          git push origin main
-        else
-          echo "No changes to push"
-        fi
+        git fetch origin main
+        git rebase origin/main
+        git push origin main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,26 +58,35 @@ jobs:
       - name: Update fuzzy tmx
         run: ./tsujiw tmx generate --tmx=l10n/tmx/fuzzy.tmx --mode=FUZZY
 
-      - name: Push changes (fuzzy tmx)
-        uses: ./.github/actions/push-changes
+      - name: Commit changes (fuzzy tmx)
+        uses: ./.github/actions/commit-changes
         with:
           message: "Update fuzzy tmx"
+
+      - name: Push changes (fuzzy tmx)
+        uses: ./.github/actions/push-changes
 
       - name: Update tmx
         run: ./tsujiw tmx generate --tmx=l10n/tmx/quarkus.tmx --mode=CONFIRMED
 
-      - name: Push changes (tmx)
-        uses: ./.github/actions/push-changes
+      - name: Commit changes (tmx)
+        uses: ./.github/actions/commit-changes
         with:
           message: "Update tmx"
+
+      - name: Push changes (tmx)
+        uses: ./.github/actions/push-changes
 
       - name: Update all stats
         run: ./tsujiw jekyll update-stats
 
-      - name: Push changes (translation stats)
-        uses: ./.github/actions/push-changes
+      - name: Commit changes (translation stats)
+        uses: ./.github/actions/commit-changes
         with:
           message: "Update translation stats"
+
+      - name: Push changes (translation stats)
+        uses: ./.github/actions/push-changes
 
       - name: Create issue if override files updated
         env:
@@ -91,10 +100,13 @@ jobs:
             fi
           fi
 
-      - name: Push changes (override stats)
-        uses: ./.github/actions/push-changes
+      - name: Commit changes (override stats)
+        uses: ./.github/actions/commit-changes
         with:
           message: "Update override stats"
+
+      - name: Push changes (override stats)
+        uses: ./.github/actions/push-changes
 
   deploy:
     name: Deploy localized site to GitHub pages

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -39,40 +39,40 @@ jobs:
           git reset --hard origin/main
           cd ..
 
-      - name: Push changes (upstream)
-        uses: ./.github/actions/push-changes
+      - name: Commit changes (upstream)
+        uses: ./.github/actions/commit-changes
         with:
           message: "Update upstream"
 
       - name: Update po files
         run: ./tsujiw jekyll extract
 
-      - name: Push changes (po files)
-        uses: ./.github/actions/push-changes
+      - name: Commit changes (po files)
+        uses: ./.github/actions/commit-changes
         with:
           message: "Update .po files"
 
       - name: Update all stats
         run: ./tsujiw jekyll update-stats
 
-      - name: Push changes (translation stats)
-        uses: ./.github/actions/push-changes
+      - name: Commit changes (translation stats)
+        uses: ./.github/actions/commit-changes
         with:
           message: "Update translation stats"
 
       - name: Apply tmx
         run: ./tsujiw po apply-tmx --tmx=l10n/tmx/quarkus.tmx
 
-      - name: Push changes (translation memory)
-        uses: ./.github/actions/push-changes
+      - name: Commit changes (translation memory)
+        uses: ./.github/actions/commit-changes
         with:
           message: "Apply translation memory"
 
       - name: Apply fuzzy tmx
         run: ./tsujiw po apply-fuzzy-tmx --tmx=l10n/tmx/fuzzy.tmx
 
-      - name: Push changes (fuzzy translation memory)
-        uses: ./.github/actions/push-changes
+      - name: Commit changes (fuzzy translation memory)
+        uses: ./.github/actions/commit-changes
         with:
           message: "Apply fuzzy translation memory"
 
@@ -86,11 +86,19 @@ jobs:
         env:
           TSUJI_TRANSLATOR_DEEPL_KEY: ${{ secrets.TRANSLATOR_DEEPL_APIKEY }}
 
-      - name: Push changes (machine translation)
+      - name: Commit changes (machine translation)
         if: always()
-        uses: ./.github/actions/push-changes
+        uses: ./.github/actions/commit-changes
         with:
           message: "Add machine translation"
+
+      - name: Push all changes
+        if: always()
+        shell: bash
+        run: |
+          git fetch origin main
+          git rebase origin/main
+          git push origin main
 
       # Fail the workflow if machine translation had errors
       - name: Check machine translation result

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -94,11 +94,7 @@ jobs:
 
       - name: Push all changes
         if: always()
-        shell: bash
-        run: |
-          git fetch origin main
-          git rebase origin/main
-          git push origin main
+        uses: ./.github/actions/push-changes
 
       # Fail the workflow if machine translation had errors
       - name: Check machine translation result


### PR DESCRIPTION
## Summary
- Split `push-changes` action into `commit-changes` (commit only) and `push-changes` (commit + push)
- Sync workflow now commits at each step but pushes only once at the end