### PR TITLE
Remove language-specific hardcodes from workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
             if grep -q "NG" l10n/stats/override.csv; then
               gh issue create \
                 --title "Corresponding files of those in the override directory are updated" \
-                --body "Corresponding files of those in the override directory are updated. see [override stats](https://github.com/quarkusio/ja.quarkus.io/blob/main/l10n/stats/override.csv) for more details."
+                --body "Corresponding files of those in the override directory are updated. see [override stats](${{ github.server_url }}/${{ github.repository }}/blob/main/l10n/stats/override.csv) for more details."
             fi
           fi
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -92,7 +92,7 @@ jobs:
           script: |
             const suffix = "${{ steps.config.outputs.surge_domain_suffix }}";
             const baseUrl = `https://pr-preview-${context.issue.number}-${suffix}`;
-            let body = `Site preview(ja): ${baseUrl}`;
+            let body = `Site preview: ${baseUrl}`;
 
             // Get changed files in this PR
             const files = await github.paginate(github.rest.pulls.listFiles, {
@@ -104,9 +104,9 @@ jobs:
 
             // Derive URL path from filename, or return null if not possible
             function toPagePath(filename) {
-              const guideMatch = filename.match(/^l10n\/po\/ja_JP\/_guides\/([^/]+)\.adoc\.po$/);
+              const guideMatch = filename.match(/^l10n\/po\/[^/]+\/_guides\/([^/]+)\.adoc\.po$/);
               if (guideMatch) return `/guides/${guideMatch[1]}`;
-              const postMatch = filename.match(/^l10n\/po\/ja_JP\/_posts\/\d{4}-\d{2}-\d{2}-([^/]+)\.adoc\.po$/);
+              const postMatch = filename.match(/^l10n\/po\/[^/]+\/_posts\/\d{4}-\d{2}-\d{2}-([^/]+)\.adoc\.po$/);
               if (postMatch) return `/blog/${postMatch[1]}/`;
               return null;
             }


### PR DESCRIPTION
## Summary
- Replace hardcoded repository URL in build.yml with `github.server_url`/`github.repository`
- Remove `(ja)` from site preview label in pull-request.yml
- Replace `ja_JP` with `[^/]+` wildcard in file path regexes in pull-request.yml

Makes workflows reusable across localization repositories without modification.