### PR TITLE
Clean up .gitignore and remove language-specific reference from setup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,12 @@
+### macOS ###
+.DS_Store
+
+### Gradle ###
 .gradle
 /build/
 out/
 !/build/.gitkeep
 !gradle/wrapper/gradle-wrapper.jar
-
-.DS_Store
-
-### STS ###
-.apt_generated
-.classpath
-.factorypath
-.project
-.settings
-.springBeans
 
 ### IntelliJ IDEA ###
 .idea
@@ -20,29 +14,28 @@ out/
 *.iml
 *.ipr
 
-### NetBeans ###
-nbproject/private/
-build/
-nbbuild/
-dist/
-nbdist/
-.nb-gradle/
-
-
 ### Project Files ###
-/docs
-/vendor
-/translated
+# Jekyll generated site output
+/docs/
+# Ruby gems and tsuji JAR cache
+/vendor/
+# Temporary translation output
+/translated/
+# PO editor backup files
 *.po~
+# gettext compiled message objects
 *.mo
+# Local development artifacts
 /.local/
+# tsuji log output
+/log/
+# RAG vector index for terminology lookup
+/l10n/rag/
 
-
-__pycache__
+### Local Configuration ###
 .env
-log/
-config/application.local.properties
-config/application-local.yaml
-config/application-local.properties
+/config/application.local.properties
+/config/application-local.yaml
+/config/application-local.properties
+# Local Claude Code instructions
 CLAUDE.local.md
-l10n/rag/

--- a/bin/setup-build-env-on-ubuntu
+++ b/bin/setup-build-env-on-ubuntu
@@ -2,7 +2,7 @@
 set -eu
 
 #
-# This script installs build tools for the ja.quarkus.io localization project.
+# This script installs build tools for the localization project.
 # It is primarily intended for use on GitHub Actions (Ubuntu Server).
 #
 


### PR DESCRIPTION
## Summary
- Remove unused .gitignore entries (STS, NetBeans, Python)
- Add comments explaining each entry
- Fix directory patterns to use consistent leading/trailing slash conventions
- Remove "ja.quarkus.io" reference from setup script comment for reusability