### PR TITLE
Improve AsciiDoc markup rules prompt

### DIFF
--- a/config/application.yaml
+++ b/config/application.yaml
@@ -27,6 +27,12 @@ tsuji:
       model: gemini-3-flash-preview
       prompts:
         system-prompt: "config/prompts/translation-system-prompt.txt"
+        asciidoc-markup-rules: "config/prompts/asciidoc-markup-rules.txt"
+
+    openai:
+      prompts:
+        system-prompt: "config/prompts/translation-system-prompt.txt"
+        asciidoc-markup-rules: "config/prompts/asciidoc-markup-rules.txt"
 
     note:
       heading: "This is a heading. Translate using nominal phrase style (体言止め) appropriate for Japanese headings."

--- a/config/prompts/asciidoc-markup-rules.txt
+++ b/config/prompts/asciidoc-markup-rules.txt
@@ -1,9 +1,14 @@
 - Preserve ALL Asciidoc markup exactly:
-  - Keep inline markup as-is: `code`, *bold*, _italic_, etc.
-  - CJK MUST have space around markup like: text `code` text, text *bold* text (NOT text`code`text or text*bold*text)
-  - Keep link/xref targets unchanged: in link:URL[text] only translate text, never URL
+  - Never change: URLs, link/xref/image targets, {attributes}, backslash escapes (\_, \\)
   - Keep cross-reference anchors (<<...>>) unchanged
-  - Keep bare URLs (https://...) exactly as they appear in the source text
-  - Keep {attribute-references} unchanged
-  - Keep image:path[alt] paths unchanged
-- In CJK, add space before link AND after ']' like: text https://url[link] (note)
+  - In link:URL[text] or xref:ref[text], only translate the text inside []
+
+- In CJK text, ensure a half-width space around inline markup spans (`text`, *text*, _text_):
+    ✓ "設定は *無効* です"
+    ✗ "設定は*無効*です"
+    ✓ "_マスター_ 接続"
+    ✗ "_ マスター _ 接続"
+
+- URLs MUST be preceded by a half-width space — Asciidoctor will not recognize a URL as a link without it:
+    ✓ "テストできます。 https://swagger.io/tools/swagger-ui/[Swagger UI] は"
+    ✗ "テストできます。https://swagger.io/tools/swagger-ui/[Swagger UI] は"


### PR DESCRIPTION
## Summary

- Rewrote `config/prompts/asciidoc-markup-rules.txt` with clearer, more concise rules and concrete good/bad examples for CJK inline markup spacing and URL spacing requirements.
- Added `asciidoc-markup-rules` prompt reference in `config/application.yaml` so the Gemini translator loads the rules as a named prompt.