### PR TITLE
Rename local config file to application.local.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,6 @@ out/
 
 ### Local Configuration ###
 .env
-/config/application.local.properties
-/config/application-local.yaml
-/config/application-local.properties
+/config/application.local.yaml
 # Local Claude Code instructions
 CLAUDE.local.md

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -1,3 +1,7 @@
+quarkus:
+  config:
+    locations: config/application.local.yaml
+
 tsuji:
   jar: https://github.com/doc-l10n-kit/tsuji/releases/download/v0.8.15/tsuji.jar
 

--- a/tsujiw
+++ b/tsujiw
@@ -293,8 +293,8 @@ public class tsujiw {
             addYamlSource(configBuilder, yamlPath, 250);
         }
 
-        // Add config/application-local.yaml if exists (higher priority)
-        Path localYamlPath = Paths.get("config/application-local.yaml");
+        // Add config/application.local.yaml if exists (higher priority)
+        Path localYamlPath = Paths.get("config/application.local.yaml");
         if (Files.exists(localYamlPath)) {
             addYamlSource(configBuilder, localYamlPath, 260);
         }


### PR DESCRIPTION
## Summary

- Rename the local configuration file from `application-local.yaml` to `application.local.yaml` for consistency with Quarkus naming conventions
- Clean up `.gitignore` by replacing three separate local config entries with a single `application.local.yaml` entry
- Add `quarkus.config.locations` to `config/application.yaml` so Quarkus natively picks up the local config file
- Update the config file path in `tsujiw` launcher to match the new filename