### PR TITLE
Add comma example to URL spacing rules prompt

### DIFF
--- a/config/prompts/asciidoc-markup-rules.txt
+++ b/config/prompts/asciidoc-markup-rules.txt
@@ -12,3 +12,5 @@
 - URLs MUST be preceded by a half-width space — Asciidoctor will not recognize a URL as a link without it:
     ✓ "テストできます。 https://swagger.io/tools/swagger-ui/[Swagger UI] は"
     ✗ "テストできます。https://swagger.io/tools/swagger-ui/[Swagger UI] は"
+    ✓ "仕様に準拠した、 https://swagger.io/docs/specification[OpenAPI 仕様] を"
+    ✗ "仕様に準拠した、https://swagger.io/docs/specification[OpenAPI 仕様] を"


### PR DESCRIPTION
## Summary

The existing URL spacing rule only shows an example with a period (。). Add a comma (、) example since Gemini frequently places URLs after commas without the required space.