### PR TITLE
Update Gemini model config for per-model thinking and escalation

### DIFF
--- a/config/application.yaml
+++ b/config/application.yaml
@@ -28,7 +28,14 @@ tsuji:
       - _redirects
 
     gemini:
-      model: gemini-3-flash-preview
+      model:
+        model-id: gemini-3-flash-preview
+        thinking:
+          thinking-level: MINIMAL
+      escalation-model:
+        model-id: gemini-3.1-pro-preview
+        thinking:
+          thinking-level: LOW
       prompts:
         system-prompt: "config/prompts/translation-system-prompt.txt"
         asciidoc-markup-rules: "config/prompts/asciidoc-markup-rules.txt"


### PR DESCRIPTION
## Summary
- Migrate to the new nested model config structure introduced in tsuji.
- Configure standard model (gemini-3-flash-preview) with MINIMAL thinking and escalation model (gemini-3.1-pro-preview) with LOW thinking for validation retries.