### PR TITLE
Update tsuji to 0.8.19 and configure DeepL language codes

### DIFF
--- a/config/application.yaml
+++ b/config/application.yaml
@@ -3,7 +3,7 @@ quarkus:
     locations: config/application.local.yaml
 
 tsuji:
-  jar: https://github.com/doc-l10n-kit/tsuji/releases/download/v0.8.18/tsuji.jar
+  jar: https://github.com/doc-l10n-kit/tsuji/releases/download/v0.8.19/tsuji.jar
 
   language:
     from: en-US
@@ -17,6 +17,10 @@ tsuji:
 
   translator:
     type: deepl
+
+    language:
+      source: en
+      target: ja
 
     target-directories:
       - _guides


### PR DESCRIPTION
## Summary

- Update tsuji to 0.8.19
- Add `translator.language.source: EN` / `translator.language.target: JA` to pass DeepL-compatible language codes

Depends on https://github.com/doc-l10n-kit/tsuji/pull/99