### PR TITLE
Re-enable HTML includes previously excluded for malformed HTML

### DIFF
--- a/config/application.yaml
+++ b/config/application.yaml
@@ -77,14 +77,14 @@ tsuji:
           - _includes/ai-frozenrag.html
           - _includes/ai-java-for-ai.html
           - _includes/ai-overview.html
-          # - _includes/ai-quarkus-for-ai.html  # Temporarily excluded due to malformed HTML (upstream issue)
-          # - _includes/benefactors.html  # Temporarily excluded due to malformed HTML (upstream issue)
+          - _includes/ai-quarkus-for-ai.html
+          - _includes/benefactors.html
           - _includes/catalog-detail-band.html
           - _includes/catalog-index-band.html
           - _includes/CF-footerband.html
           - _includes/container-first.html
           - _includes/developer-joy.html
-          # - _includes/discussion.html  # Temporarily excluded due to malformed HTML (upstream issue)
+          - _includes/discussion.html
           - _includes/events-discussions-band.html
           - _includes/feedback-community-band.html
           - _includes/get-started-band.html
@@ -111,9 +111,9 @@ tsuji:
           - _includes/performance.html
           - _includes/project-footer.html
           - _includes/publication-entries.html
-          # - _includes/spring-features-band.html  # Temporarily excluded due to malformed HTML (upstream issue)
+          - _includes/spring-features-band.html
           - _includes/spring-migrate-books.html
-          # - _includes/spring-migrate-main.html  # Temporarily excluded due to malformed HTML (upstream issue)
+          - _includes/spring-migrate-main.html
           - _includes/spring-userstory-callout.html
           - _includes/standards.html
           - _includes/support-help-band.html


### PR DESCRIPTION
## Summary

- Re-enable extraction for HTML includes that were temporarily excluded due to upstream malformed HTML issues
- Affected files: `ai-quarkus-for-ai.html`, `benefactors.html`, `discussion.html`, `spring-features-band.html`, `spring-migrate-main.html`